### PR TITLE
Update logistics_project/apps/malawi/templates/malawi/new/reports/dashbo...

### DIFF
--- a/logistics_project/apps/malawi/templates/malawi/new/reports/dashboard.html
+++ b/logistics_project/apps/malawi/templates/malawi/new/reports/dashboard.html
@@ -3,9 +3,7 @@
 {% block report_content %}
 
 <form method="get" id="selector">
-	<fieldset>
 	{% include "malawi/partials/location_selector.html" %}
-	</fieldset>
     <input type="submit" value="Go!" />
 </form>
 


### PR DESCRIPTION
...ard.html

Removed <fieldset> tag from lines 6 and 8 - was causing the "go" button to move to the next line, and it didn't appear to have a function here. Other places on the site with similar functionality do not use <fieldset>. If we do not remove it, I suggest we change line 90 of lalawi-new.css to add "float: left; and width: 20em;".
