### PR TITLE
Update logistics_project/apps/malawi/templates/malawi/new/base.html

### DIFF
--- a/logistics_project/apps/malawi/templates/malawi/new/base.html
+++ b/logistics_project/apps/malawi/templates/malawi/new/base.html
@@ -51,7 +51,7 @@
                 <tr><th colspan="3">National Stock Out Rate</th></tr>
                 <tr><th>Product</th><th>HSAs</th><th>% SO</th></tr>
                 {% for product, pct in product_stockout_pcts.items %}                
-                    <tr><td>{{ product.sms_code }}</td>
+                    <tr class="{{forloop.counter|divisibleby:2|yesno:"even,odd"}}"><td>{{ product.sms_code }}</td>
                         <td>{{ pct.1 }}</td>
                         <td>{{ pct.0|floatformat }}%</td>
                     </tr>


### PR DESCRIPTION
In Line 54, added 

class="{{forloop.counter|divisibleby:2|yesno:"even,odd"}}"

to the <tr> tag. I don't know if this is good (or even functional) syntax. I modified it from some code on this page: 

http://stackoverflow.com/questions/459161/alternate-row-coloring-in-django-template-with-more-than-one-set-of-rows

It was in a comment about the most-voted-up answer.

The reason for this pull request is so that we can add a grey background on every-other row, starting with "bi | 9 | 0%" 
