### PR TITLE
Update logistics_project/apps/malawi/static/css/malawi-new.css

### DIFF
--- a/logistics_project/apps/malawi/static/css/malawi-new.css
+++ b/logistics_project/apps/malawi/static/css/malawi-new.css
@@ -95,6 +95,9 @@ fieldset {
     border: none;
 }
 
+thead th {
+    max-width: 200px;
+}
 
 /* flot */
 div.tickLabel {


### PR DESCRIPTION
(lines 98-100)

Overrode the thead th property from tables.css, adding max-width (see below) 

One of the requests was to have table columns be of equal width. This doesn't really make complete sense; however, what I take from the request is that they want some of the table columns to be MORE EQUAL in width. So I applied a max-width property to make it so that none of the columns get too wide. I tested this on a few tables (using Firebug), and it seemed to look OK, although it didn't always change in ways that I expected. What are your thoughts? Thanks, Daniel
