### PR TITLE
Delivery quantities

### DIFF
--- a/logistics_project/apps/tanzania/handlers/delivery.py
+++ b/logistics_project/apps/tanzania/handlers/delivery.py
@@ -85,7 +85,7 @@ class DeliveryHandler(KeywordHandler,TaggingHandler):
                                     .values_list("product", flat=True))
 
             self.respond(_(config.Messages.DELIVERY_CONFIRM),
-                         reply_list=','.join(sorted(stock_report.reported_products())))
+                         reply_list=stock_report.all_sorted())
 
             SupplyPointStatus.objects.create(supply_point=sp,
                                              status_type=SupplyPointStatusTypes.DELIVERY_FACILITY,

--- a/logistics_project/apps/tanzania/tests/delivery.py
+++ b/logistics_project/apps/tanzania/tests/delivery.py
@@ -46,7 +46,7 @@ class TestDelivery(TanzaniaTestScriptBase):
         script = """
             778 > nimepokea Id 400 Dp 569 Ip 678
             778 < %(received_message)s
-            """ % {'received_message': _(config.Messages.DELIVERED_CONFIRM) % {"reply_list":"dp,id,ip"}}
+            """ % {'received_message': _(config.Messages.DELIVERED_CONFIRM) % {"reply_list":"dp 569, id 400, ip 678"}}
         self.runScript(script)
         self.assertEqual(3, ProductStock.objects.count())
         for ps in ProductStock.objects.all():


### PR DESCRIPTION
Add a sorted equivalent of the all method to keep the ordering that was present in the command originally.

Instead of "dp,id,ip" it will now use "dp 569, id 400, ip 678".

Relies on https://github.com/dimagi/rapidsms-logistics/pull/13.

I put it in the submodule because it is the same functionality but the tz-master branch was previously pointing to a reasonably old commit (https://github.com/dimagi/rapidsms-logistics/tree/4fad9d384b29fe05fff4909a6532322a4ce10bc1). Let me know if I should just put this functionality in the logistics code instead.
