### PR TITLE
Fix download type

### DIFF
--- a/logistics_project/apps/tanzania/views.py
+++ b/logistics_project/apps/tanzania/views.py
@@ -692,7 +692,8 @@ def download_supervision_doc(request, document_id):
 
     if type is None:
         type = 'application/octet-stream'
-        response['Content-Type'] = type
+
+    response['Content-Type'] = type
 
     if encoding is not None:
         response['Content-Encoding'] = encoding


### PR DESCRIPTION
A bug was reported where Firefox couldn't figure out the file type properly. This fixes that.
