### PR TITLE
Added created_at into location api

### DIFF
--- a/logistics_project/apps/api/resources/v0_1.py
+++ b/logistics_project/apps/api/resources/v0_1.py
@@ -101,6 +101,7 @@ class LocationResources(ModelResource):
         try:
             sp = SupplyPoint.objects.get(pk=bundle.data['id'])
             bundle.data['groups'] = list(sp.groups.all())
+            bundle.data['created_at'] = sp.created_at
             if int(bundle.request.GET.get('with_historical_groups', 0)) == 1:
                 summaries = GroupSummary.objects.filter(
                     org_summary__supply_point=sp,


### PR DESCRIPTION
@czue 
It turns out that we also need to know when location was created in order to generate valid reporting data. 