### PR TITLE
[refactor] Use base_level instead of is_facility flag

### DIFF
--- a/logistics_project/apps/malawi/admin.py
+++ b/logistics_project/apps/malawi/admin.py
@@ -18,8 +18,8 @@ admin.site.register(Organization)
 # warehouse admin
 class ReportingRateAdmin(admin.ModelAdmin):
     model = ReportingRate
-    list_display = ('supply_point', 'date', 'is_facility', 'total', 'reported', 'on_time', 'complete')
-    list_filter = ('supply_point__type', 'date', 'is_facility', 'supply_point')
+    list_display = ('supply_point', 'date', 'base_level', 'total', 'reported', 'on_time', 'complete')
+    list_filter = ('supply_point__type', 'date', 'base_level', 'supply_point')
 
 
 class ProductAvailabilityDataAdmin(admin.ModelAdmin):

--- a/logistics_project/apps/malawi/extensions/logistics/producttype.py
+++ b/logistics_project/apps/malawi/extensions/logistics/producttype.py
@@ -1,8 +1,9 @@
 from django.db import models
+from logistics.util import config
 
 
 class MalawiProductTypeExtension(models.Model):
-    is_facility = models.BooleanField(default=False)
+    base_level = models.CharField(max_length=1, default=config.BaseLevel.HSA)
 
     class Meta:
         abstract = True

--- a/logistics_project/apps/malawi/migrations/0020_use_base_level_instead_of_is_facility.py
+++ b/logistics_project/apps/malawi/migrations/0020_use_base_level_instead_of_is_facility.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'ReportingRate.is_facility'
+        db.delete_column('malawi_reportingrate', 'is_facility')
+
+        # Adding field 'ReportingRate.base_level'
+        db.add_column('malawi_reportingrate', 'base_level',
+                      self.gf('django.db.models.fields.CharField')(default='h', max_length=1),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Adding field 'ReportingRate.is_facility'
+        db.add_column('malawi_reportingrate', 'is_facility',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Deleting field 'ReportingRate.base_level'
+        db.delete_column('malawi_reportingrate', 'base_level')
+
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'locations.location': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Location'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'parent_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'parent_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['locations.Point']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'locations'", 'null': 'True', 'to': "orm['locations.LocationType']"})
+        },
+        'locations.locationtype': {
+            'Meta': {'object_name': 'LocationType'},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50', 'primary_key': 'True'})
+        },
+        'locations.point': {
+            'Meta': {'object_name': 'Point'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'max_digits': '13', 'decimal_places': '10'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'max_digits': '13', 'decimal_places': '10'})
+        },
+        'logistics.contactrole': {
+            'Meta': {'object_name': 'ContactRole'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'responsibilities': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.Responsibility']", 'null': 'True', 'blank': 'True'})
+        },
+        'logistics.defaultmonthlyconsumption': {
+            'Meta': {'unique_together': "(('supply_point_type', 'product'),)", 'object_name': 'DefaultMonthlyConsumption'},
+            'default_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'supply_point_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPointType']"})
+        },
+        'logistics.product': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Product'},
+            'average_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'emergency_order_level': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'equivalents': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'equivalents_rel_+'", 'null': 'True', 'to': "orm['logistics.Product']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'product_code': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'sms_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10', 'db_index': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ProductType']"}),
+            'units': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.producttype': {
+            'Meta': {'object_name': 'ProductType'},
+            'base_level': ('django.db.models.fields.CharField', [], {'default': "'h'", 'max_length': '1'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.responsibility': {
+            'Meta': {'object_name': 'Responsibility'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'logistics.supplypoint': {
+            'Meta': {'ordering': "['name']", 'object_name': 'SupplyPoint'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.SupplyPointGroup']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_reported': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['locations.Location']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'supplied_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPointType']"})
+        },
+        'logistics.supplypointgroup': {
+            'Meta': {'object_name': 'SupplyPointGroup'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'logistics.supplypointtype': {
+            'Meta': {'object_name': 'SupplyPointType'},
+            'code': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50', 'primary_key': 'True'}),
+            'default_monthly_consumptions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.Product']", 'null': 'True', 'through': "orm['logistics.DefaultMonthlyConsumption']", 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'malawi.alert': {
+            'Meta': {'object_name': 'Alert'},
+            'eo_total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'eo_with_resupply': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'eo_without_resupply': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'have_stockouts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num_hsas': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'order_readys': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'products_approved': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'products_requested': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'reporting_receipts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total_requests': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'without_products_managed': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        'malawi.calculatedconsumption': {
+            'Meta': {'object_name': 'CalculatedConsumption'},
+            'calculated_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'time_needing_data': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'time_stocked_out': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'time_with_data': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.currentconsumption': {
+            'Meta': {'object_name': 'CurrentConsumption'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'current_daily_consumption': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'stock_on_hand': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.historicalstock': {
+            'Meta': {'object_name': 'HistoricalStock'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'stock': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.orderfulfillment': {
+            'Meta': {'object_name': 'OrderFulfillment'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'quantity_received': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'quantity_requested': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.orderrequest': {
+            'Meta': {'object_name': 'OrderRequest'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'emergency': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.organization': {
+            'Meta': {'object_name': 'Organization'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'managed_supply_points': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'malawi.productavailabilitydata': {
+            'Meta': {'object_name': 'ProductAvailabilityData'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'emergency_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'good_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'managed': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_emergency_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_good_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_over_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_under_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_with_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_without_data': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_without_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'over_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'under_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'with_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'without_data': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'without_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        'malawi.productavailabilitydatasummary': {
+            'Meta': {'object_name': 'ProductAvailabilityDataSummary'},
+            'any_emergency_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_good_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_managed': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_over_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_under_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_with_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_without_data': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_without_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.refrigeratormalfunction': {
+            'Meta': {'object_name': 'RefrigeratorMalfunction'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'malfunction_reason': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'reported_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['rapidsms.Contact']"}),
+            'reported_on': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'resolved_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'responded_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'sent_to': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'to': "orm['logistics.SupplyPoint']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['logistics.SupplyPoint']"})
+        },
+        'malawi.reportingrate': {
+            'Meta': {'object_name': 'ReportingRate'},
+            'base_level': ('django.db.models.fields.CharField', [], {'default': "'h'", 'max_length': '1'}),
+            'complete': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'on_time': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'reported': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.timetracker': {
+            'Meta': {'object_name': 'TimeTracker'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'time_in_seconds': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'rapidsms.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'commodities': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'reported_by'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['logistics.Product']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '6', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'needs_reminders': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'organization': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['malawi.Organization']", 'null': 'True', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ContactRole']", 'null': 'True', 'blank': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['malawi']

--- a/logistics_project/apps/malawi/templates/malawi/new/base.html
+++ b/logistics_project/apps/malawi/templates/malawi/new/base.html
@@ -22,7 +22,7 @@
             {% for report in report_list %}
                 {% if report.slug %}
                     <li class="report {% ifequal slug report.slug %}selected{% endifequal %}">
-                        <a href="{% if is_facility %}{{ settings.EPI_REPORT_URL }}{% else %}{{ settings.REPORT_URL }}{% endif %}/{{ report.slug }}/{{ querystring }}">{{ report.name }}</a>
+                        <a href="{% if base_level_is_facility %}{{ settings.EPI_REPORT_URL }}{% else %}{{ settings.REPORT_URL }}{% endif %}/{{ report.slug }}/{{ querystring }}">{{ report.name }}</a>
                     </li>
                 {% endif %}
              {% empty %}
@@ -51,8 +51,8 @@
                 <tr><th colspan="2">Number Registered</th></tr>
                 <tr><th>Districts</th><td>{{ district_count }}</td></tr>
                 <tr><th>H facilities</th><td>{{ facility_count }}</td></tr>
-                {% if not is_facility %}
-                <tr><th>HSAs</th><td>{{ hsas }}</td></tr>
+                {% if base_level_is_hsa %}
+                <tr><th>{{ base_level_plural_description }}</th><td>{{ hsas }}</td></tr>
                 {% endif %}
             </table>
             <table>
@@ -62,7 +62,7 @@
                 <tr><th colspan="3">National Stock Out Rate</th></tr>
                 <tr>
                     <th>Product</th>
-                    <th>{% if is_facility %}Facilities{% else %}HSAs{% endif %}</th>
+                    <th>{{ base_level_plural_description }}</th>
                     <th>% SO</th>
                 </tr>
                 {% for product, pct in product_stockout_pcts.items %}                

--- a/logistics_project/apps/malawi/templates/malawi/new/reports/dashboard.html
+++ b/logistics_project/apps/malawi/templates/malawi/new/reports/dashboard.html
@@ -33,7 +33,7 @@
 
 <div class="module">
     <h2>Current stock status by product</h2>
-    {% warehouse_product_availability_summary location window_date default_chart_width %} 
+    {% warehouse_product_availability_summary location window_date default_chart_width 300 base_level %}
 </div>
 
 {% endblock %}

--- a/logistics_project/apps/malawi/templates/malawi/new/reports/reporting-rate.html
+++ b/logistics_project/apps/malawi/templates/malawi/new/reports/reporting-rate.html
@@ -1,7 +1,7 @@
 {% extends "malawi/new/base.html" %}
 {% block report_content %}
 
-{% with is_facility as exclude_facilities %}
+{% with base_level_is_facility as exclude_facilities %}
 {% include "malawi/partials/selector_form.html" %}
 {% endwith %}
 

--- a/logistics_project/apps/malawi/templates/malawi/new/reports/stock-status.html
+++ b/logistics_project/apps/malawi/templates/malawi/new/reports/stock-status.html
@@ -2,7 +2,7 @@
 {% load malawi_warehouse_tags %}
 {% block report_content %}
 <form method="get" class="selector">
-    {% with is_facility as exclude_facilities %}
+    {% with base_level_is_facility as exclude_facilities %}
     {% include "malawi/partials/location_selector.html" %}
     {% endwith %}
     <input type="hidden" id="_start" name="from" value="{{ request.datespan.startdate|date:'F' }} {{ request.datespan.startdate|date:'Y' }}" />
@@ -12,7 +12,7 @@
 
 <div class="module">
     <h2>Current stock status by product</h2>
-    {% warehouse_product_availability_summary location window_date default_chart_width 300 is_facility %}
+    {% warehouse_product_availability_summary location window_date default_chart_width 300 base_level %}
 </div>
 
 <div class="module">
@@ -44,7 +44,7 @@
         <input type="hidden" id="_loc" name="place" value="{{ location.code }}" />
         <input type="submit" value="Go!" />
 	</form>
-    <h2>% {% if is_facility %}Facility{% else %}HSA{% endif %} stockouts by product</h2>
+    <h2>% {{ base_level_description }} stockouts by product</h2>
     <a href="{{ request.get_full_path }}{% if request.GET %}&{% else %}?{% endif %}export_csv=true&table=stockout-table">
         <img src="/static/malawi/images/download-csv-icon.gif" id="download-{{ table.id }}" class="download-csv" />
     </a>
@@ -55,7 +55,7 @@
 
 {% if months_of_stock_table %}
     <div class="module">
-        <h2>{% if is_facility %}Facility{% else %}HSA{% endif %} months of stock by product</h2>
+        <h2>{{ base_level_description }} months of stock by product</h2>
         {% with months_of_stock_table as table %}
             {% include "malawi/new/partials/generic-table.html" %}
         {% endwith %}

--- a/logistics_project/apps/malawi/templatetags/malawi_warehouse_tags.py
+++ b/logistics_project/apps/malawi/templatetags/malawi_warehouse_tags.py
@@ -3,16 +3,17 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from logistics.models import SupplyPoint
 from logistics.templatetags.logistics_report_tags import r_2_s_helper
+from logistics.util import config
 from logistics_project.apps.malawi.warehouse.report_utils import WarehouseProductAvailabilitySummary
 from logistics_project.apps.malawi.util import get_country_sp
 
 register = template.Library()
 
 @register.simple_tag
-def warehouse_product_availability_summary(location, date, width=900, height=300, is_facility=False):
+def warehouse_product_availability_summary(location, date, width=900, height=300, base_level=config.BaseLevel.HSA):
     sp = SupplyPoint.objects.get(location=location) if location else get_country_sp()
     try:
-        summary = WarehouseProductAvailabilitySummary(sp, date, width, height, is_facility=is_facility)
+        summary = WarehouseProductAvailabilitySummary(sp, date, width, height, base_level=base_level)
         return r_2_s_helper("logistics/partials/product_availability_summary.html",
                              {"summary": summary})
     except ObjectDoesNotExist:

--- a/logistics_project/apps/malawi/warehouse/models.py
+++ b/logistics_project/apps/malawi/warehouse/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from logistics.warehouse_models import ReportingModel, BaseReportingModel
 from logistics_project.apps.malawi.util import fmt_pct, pct, hsas_below
-from static.malawi.config import TimeTrackerTypes
+from static.malawi.config import TimeTrackerTypes, BaseLevel
 from datetime import datetime
 from dimagi.utils.dates import first_of_next_month, delta_secs
 
@@ -90,11 +90,11 @@ class ReportingRate(MalawiWarehouseModel):
     """
     # Dashboard: Reporting Rates
     # Reporting Rates: all
-    is_facility = models.BooleanField(default=False)
     total = models.PositiveIntegerField(default=0)
     reported = models.PositiveIntegerField(default=0)
     on_time = models.PositiveIntegerField(default=0)
     complete = models.PositiveIntegerField(default=0)
+    base_level = models.CharField(max_length=1, default=BaseLevel.HSA)
     
     @property
     def late(self): 

--- a/logistics_project/apps/malawi/warehouse/report_views/dashboard.py
+++ b/logistics_project/apps/malawi/warehouse/report_views/dashboard.py
@@ -75,6 +75,6 @@ class View(warehouse_view.DashboardView):
             "graphdata": get_multiple_reporting_rates_chart(
                 child_sps,
                 window_date,
-                is_facility=request.is_facility
+                base_level=request.base_level
             ),
         }

--- a/logistics_project/apps/malawi/warehouse/report_views/reporting_rate.py
+++ b/logistics_project/apps/malawi/warehouse/report_views/reporting_rate.py
@@ -22,7 +22,7 @@ class View(warehouse_view.DistrictOnlyView):
     automatically_adjust_datespan = True
 
     def get_min_start_date(self, request):
-        result = ReportingRate.objects.filter(is_facility=request.is_facility).aggregate(min_date=Min('date'))
+        result = ReportingRate.objects.filter(base_level=request.base_level).aggregate(min_date=Min('date'))
         return result['min_date']
 
     def custom_context(self, request):
@@ -37,7 +37,7 @@ class View(warehouse_view.DistrictOnlyView):
         for year, month in months_between(request.datespan.startdate, 
                                           request.datespan.enddate):
             dt = datetime(year, month, 1)
-            months[dt] = ReportingRate.objects.get(supply_point=sp, date=dt, is_facility=request.is_facility)
+            months[dt] = ReportingRate.objects.get(supply_point=sp, date=dt, base_level=request.base_level)
 
         month_data = [
             [dt.strftime("%B")] + [getattr(rr, "pct_%s" % k) for k in shared_slugs]
@@ -61,7 +61,7 @@ class View(warehouse_view.DistrictOnlyView):
                     try:
                         rr = ReportingRate.objects.get(supply_point=sp,
                                                        date=datetime(year, month, 1),
-                                                       is_facility=request.is_facility)
+                                                       base_level=request.base_level)
                         spdata['total'] += rr.total
                         for k in shared_slugs:
                             spdata[k] += getattr(rr, k)
@@ -119,7 +119,7 @@ class View(warehouse_view.DistrictOnlyView):
                 rr = ReportingRate.objects.filter(
                     supply_point=hsa,
                     date__range=(request.datespan.startdate, request.datespan.enddate),
-                    is_facility=request.is_facility,
+                    base_level=request.base_level,
                 )
                 total = non_rep = on_time = late = complete = 0
                 for r in rr:
@@ -134,9 +134,8 @@ class View(warehouse_view.DistrictOnlyView):
             "month_table": month_table,
             "location_table": location_table,
             "hsa_table": hsa_table,
-            # todo: pass is_facility though to get_reporting_rates_chart
             "graphdata": get_reporting_rates_chart(request.location,
                                                    request.datespan.startdate,
                                                    request.datespan.enddate,
-                                                   is_facility=request.is_facility)
+                                                   base_level=request.base_level)
         }

--- a/logistics_project/apps/malawi/warehouse/runner.py
+++ b/logistics_project/apps/malawi/warehouse/runner.py
@@ -136,8 +136,8 @@ class MalawiWarehouseRunner(WarehouseRunner):
 
         update_historical_data()
 
-    def update_base_level_data(self, supply_point, start, end, all_products=None, base_level=config.BaselLevel.HSA):
-        base_level_is_hsa = (base_level == config.BaselLevel.HSA)
+    def update_base_level_data(self, supply_point, start, end, all_products=None, base_level=config.BaseLevel.HSA):
+        base_level_is_hsa = (base_level == config.BaseLevel.HSA)
 
         all_products = all_products or Product.objects.all()
         products_managed = set([c.pk for c in supply_point.commodities_stocked()])
@@ -179,11 +179,11 @@ class MalawiWarehouseRunner(WarehouseRunner):
             if not self.skip_reporting_rates:
                 _aggregate(ReportingRate, window_date, place, relevant_children,
                            fields=['total', 'reported', 'on_time', 'complete'],
-                           additonal_query_params={'base_level': config.BaselLevel.HSA})
+                           additonal_query_params={'base_level': config.BaseLevel.HSA})
                 if settings.ENABLE_FACILITY_WORKFLOWS:
                     _aggregate(ReportingRate, window_date, place, relevant_children,
                            fields=['total', 'reported', 'on_time', 'complete'],
-                           additonal_query_params={'base_level': config.BaselLevel.FACILITY})
+                           additonal_query_params={'base_level': config.BaseLevel.FACILITY})
 
             if not self.skip_product_availability:
                 for p in all_products:

--- a/logistics_project/apps/malawi/warehouse/runner.py
+++ b/logistics_project/apps/malawi/warehouse/runner.py
@@ -10,6 +10,7 @@ from rapidsms.contrib.messagelog.models import Message
 from logistics.models import SupplyPoint, ProductReport, StockTransaction,\
     ProductStock, Product, StockRequest, StockRequestStatus
 from logistics.const import Reports
+from logistics.util import config
 from logistics.warehouse_models import SupplyPointWarehouseRecord
 
 from warehouse.runner import WarehouseRunner
@@ -108,7 +109,7 @@ class MalawiWarehouseRunner(WarehouseRunner):
                 facilities = facilities[:self.facility_limit]
             for i, facility in enumerate(facilities):
                 print "processing facility %s (%s) (%s of %s)" % (facility.name, str(facility.id), i, count)
-                self.update_base_level_data(facility, start, end, all_products, is_facility=True)
+                self.update_base_level_data(facility, start, end, all_products, base_level=config.BaseLevel.FACILITY)
 
         if not self.skip_consumption:
             update_consumption_times(run_record.start_run)
@@ -135,30 +136,31 @@ class MalawiWarehouseRunner(WarehouseRunner):
 
         update_historical_data()
 
-    def update_base_level_data(self, supply_point, start, end, all_products=None, is_facility=False):
+    def update_base_level_data(self, supply_point, start, end, all_products=None, base_level=config.BaselLevel.HSA):
+        base_level_is_hsa = (base_level == config.BaselLevel.HSA)
 
         all_products = all_products or Product.objects.all()
         products_managed = set([c.pk for c in supply_point.commodities_stocked()])
 
-        if not self.skip_current_consumption and not is_facility:
+        if not self.skip_current_consumption and base_level_is_hsa:
             update_current_consumption(supply_point)
 
         for year, month in months_between(start, end):
             report_period = ReportPeriod(supply_point, datetime(year, month, 1), start, end)
 
             if not self.skip_reporting_rates:
-                _update_reporting_rate(supply_point, report_period, products_managed, is_facility)
-            if not self.skip_product_availability and not is_facility:
+                _update_reporting_rate(supply_point, report_period, products_managed, base_level)
+            if not self.skip_product_availability and base_level_is_hsa:
                 _update_product_availability(supply_point, report_period, all_products)
-            if not self.skip_lead_times and not is_facility:
+            if not self.skip_lead_times and base_level_is_hsa:
                 _update_lead_times(supply_point, report_period)
-            if not self.skip_order_requests and not is_facility:
+            if not self.skip_order_requests and base_level_is_hsa:
                 _update_order_requests(supply_point, report_period, all_products)
-            if not self.skip_order_fulfillment and not is_facility:
+            if not self.skip_order_fulfillment and base_level_is_hsa:
                 _update_order_fulfillment(supply_point, report_period, all_products)
-            if not self.skip_consumption and not is_facility:
+            if not self.skip_consumption and base_level_is_hsa:
                 update_consumption(report_period)
-            if not self.skip_historical_stock and not is_facility:
+            if not self.skip_historical_stock and base_level_is_hsa:
                 _update_historical_stock(supply_point, report_period, all_products)
 
     def update_non_hsa_data(self, place, start, end, since, all_products=None):
@@ -177,11 +179,11 @@ class MalawiWarehouseRunner(WarehouseRunner):
             if not self.skip_reporting_rates:
                 _aggregate(ReportingRate, window_date, place, relevant_children,
                            fields=['total', 'reported', 'on_time', 'complete'],
-                           additonal_query_params={'is_facility': False})
+                           additonal_query_params={'base_level': config.BaselLevel.HSA})
                 if settings.ENABLE_FACILITY_WORKFLOWS:
                     _aggregate(ReportingRate, window_date, place, relevant_children,
                            fields=['total', 'reported', 'on_time', 'complete'],
-                           additonal_query_params={'is_facility': True})
+                           additonal_query_params={'base_level': config.BaselLevel.FACILITY})
 
             if not self.skip_product_availability:
                 for p in all_products:
@@ -532,7 +534,7 @@ def aggregate_types_in_order():
     yield 'c', 'country'
 
 
-def _update_reporting_rate(supply_point, report_period, products_managed, is_facility):
+def _update_reporting_rate(supply_point, report_period, products_managed, base_level):
     """
     Process reports (on time versus late, versus at all and completeness)
     """
@@ -540,7 +542,7 @@ def _update_reporting_rate(supply_point, report_period, products_managed, is_fac
         timedelta(days=settings.LOGISTICS_DAYS_UNTIL_LATE_PRODUCT_REPORT)
 
     reports_in_range = ProductReport.objects.filter(
-        product__type__is_facility=is_facility,
+        product__type__base_level=base_level,
         supply_point=supply_point,
         report_type__code=Reports.SOH,
         report_date__gte=report_period.period_start,
@@ -549,7 +551,7 @@ def _update_reporting_rate(supply_point, report_period, products_managed, is_fac
     period_rr = ReportingRate.objects.get_or_create(
         supply_point=supply_point,
         date=report_period.window_date,
-        is_facility=is_facility,
+        base_level=base_level,
     )[0]
     period_rr.total = 1
     period_rr.reported = 1 if reports_in_range else period_rr.reported

--- a/logistics_project/apps/malawi/warehouse/warehouse_view.py
+++ b/logistics_project/apps/malawi/warehouse/warehouse_view.py
@@ -54,7 +54,7 @@ class MalawiWarehouseView(ReportView):
         country = get_country_sp()
         products = Product.objects.filter(
             is_active=True,
-            type__is_facility=request.is_facility
+            type__base_level=request.base_level
         ).order_by('sms_code')
         date = current_report_period()
         
@@ -76,7 +76,7 @@ class MalawiWarehouseView(ReportView):
         pct_reported = '?'
         try:
             current_rr = ReportingRate.objects.get(
-                date=date, supply_point=country, is_facility=request.is_facility,
+                date=date, supply_point=country, base_level=request.base_level,
             )
             pct_reported = current_rr.pct_reported
         except ReportingRate.DoesNotExist:
@@ -85,7 +85,7 @@ class MalawiWarehouseView(ReportView):
         default_sp = get_default_supply_point(request.user)
         visible_facilities = get_visible_facilities(request.user).order_by('parent_id')
         visible_hsas = []
-        if not request.is_facility:
+        if request.base_level_is_hsa:
             visible_hsas = get_visible_hsas(request.user)
 
         querystring = '?'
@@ -110,10 +110,14 @@ class MalawiWarehouseView(ReportView):
             "querystring": querystring,
             "show_report_nav": self.show_report_nav,
             "window_date": current_report_period(),
-            "is_facility": request.is_facility,
+            "base_level": request.base_level,
+            "base_level_is_hsa": request.base_level_is_hsa,
+            "base_level_is_facility": request.base_level_is_facility,
+            "base_level_description": config.BaseLevel.get_base_level_description(request.base_level),
+            "base_level_plural_description": config.BaseLevel.get_base_level_description(request.base_level, plural=True),
         })
 
-        if request.is_facility:
+        if request.base_level_is_facility:
             base_context['report_list'] = [
                 {'name': name, 'slug': slug}
                 for name, slug in settings.EPI_REPORT_LIST.iteritems()

--- a/logistics_project/deployments/malawi/migrations/logistics/0008_use_base_level_instead_of_is_facility.py
+++ b/logistics_project/deployments/malawi/migrations/logistics/0008_use_base_level_instead_of_is_facility.py
@@ -1,0 +1,321 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'ProductType.is_facility'
+        db.delete_column('logistics_producttype', 'is_facility')
+
+        # Adding field 'ProductType.base_level'
+        db.add_column('logistics_producttype', 'base_level',
+                      self.gf('django.db.models.fields.CharField')(default='h', max_length=1),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Adding field 'ProductType.is_facility'
+        db.add_column('logistics_producttype', 'is_facility',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+        # Deleting field 'ProductType.base_level'
+        db.delete_column('logistics_producttype', 'base_level')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'locations.location': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Location'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'parent_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'parent_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['locations.Point']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'locations'", 'null': 'True', 'to': "orm['locations.LocationType']"})
+        },
+        'locations.locationtype': {
+            'Meta': {'object_name': 'LocationType'},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50', 'primary_key': 'True'})
+        },
+        'locations.point': {
+            'Meta': {'object_name': 'Point'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'max_digits': '13', 'decimal_places': '10'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'max_digits': '13', 'decimal_places': '10'})
+        },
+        'logistics.contactrole': {
+            'Meta': {'object_name': 'ContactRole'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'responsibilities': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.Responsibility']", 'null': 'True', 'blank': 'True'})
+        },
+        'logistics.defaultmonthlyconsumption': {
+            'Meta': {'unique_together': "(('supply_point_type', 'product'),)", 'object_name': 'DefaultMonthlyConsumption'},
+            'default_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'supply_point_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPointType']"})
+        },
+        'logistics.historicalstockcache': {
+            'Meta': {'object_name': 'HistoricalStockCache'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'month': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']", 'null': 'True'}),
+            'stock': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'year': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        'logistics.logisticsprofile': {
+            'Meta': {'object_name': 'LogisticsProfile'},
+            'designation': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['locations.Location']", 'null': 'True', 'blank': 'True'}),
+            'organization': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['malawi.Organization']", 'null': 'True', 'blank': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'logistics.nagrecord': {
+            'Meta': {'object_name': 'NagRecord'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'nag_type': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'report_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'warning': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        'logistics.product': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Product'},
+            'average_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'emergency_order_level': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'equivalents': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'equivalents_rel_+'", 'null': 'True', 'to': "orm['logistics.Product']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'product_code': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'sms_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10', 'db_index': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ProductType']"}),
+            'units': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.productreport': {
+            'Meta': {'object_name': 'ProductReport'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['messagelog.Message']", 'null': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {}),
+            'report_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow', 'db_index': 'True'}),
+            'report_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ProductReportType']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'logistics.productreporttype': {
+            'Meta': {'object_name': 'ProductReportType'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.productstock': {
+            'Meta': {'unique_together': "(('supply_point', 'product'),)", 'object_name': 'ProductStock'},
+            'auto_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'days_stocked_out': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'manual_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'use_auto_consumption': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'logistics.producttype': {
+            'Meta': {'object_name': 'ProductType'},
+            'base_level': ('django.db.models.fields.CharField', [], {'default': "'h'", 'max_length': '1'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.requisitionreport': {
+            'Meta': {'object_name': 'RequisitionReport'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['messagelog.Message']"}),
+            'report_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'submitted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'logistics.responsibility': {
+            'Meta': {'object_name': 'Responsibility'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'logistics.stockrequest': {
+            'Meta': {'object_name': 'StockRequest'},
+            'amount_approved': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'amount_received': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'amount_requested': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'balance': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True'}),
+            'canceled_for': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.StockRequest']", 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_emergency': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'received_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'received_by'", 'null': 'True', 'to': "orm['rapidsms.Contact']"}),
+            'received_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'requested_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'requested_by'", 'null': 'True', 'to': "orm['rapidsms.Contact']"}),
+            'requested_on': ('django.db.models.fields.DateTimeField', [], {}),
+            'responded_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'responded_by'", 'null': 'True', 'to': "orm['rapidsms.Contact']"}),
+            'responded_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'response_status': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '20', 'db_index': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'logistics.stocktransaction': {
+            'Meta': {'object_name': 'StockTransaction'},
+            'beginning_balance': ('django.db.models.fields.IntegerField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'ending_balance': ('django.db.models.fields.IntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'product_report': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ProductReport']", 'null': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'logistics.stocktransfer': {
+            'Meta': {'object_name': 'StockTransfer'},
+            'amount': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'closed_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'giver': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'giver'", 'null': 'True', 'to': "orm['logistics.SupplyPoint']"}),
+            'giver_unknown': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'initiated_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'receiver': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'receiver'", 'to': "orm['logistics.SupplyPoint']"}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        'logistics.supplypoint': {
+            'Meta': {'ordering': "['name']", 'object_name': 'SupplyPoint'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.SupplyPointGroup']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_reported': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['locations.Location']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'supplied_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPointType']"})
+        },
+        'logistics.supplypointgroup': {
+            'Meta': {'object_name': 'SupplyPointGroup'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'logistics.supplypointtype': {
+            'Meta': {'object_name': 'SupplyPointType'},
+            'code': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50', 'primary_key': 'True'}),
+            'default_monthly_consumptions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.Product']", 'null': 'True', 'through': "orm['logistics.DefaultMonthlyConsumption']", 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.supplypointwarehouserecord': {
+            'Meta': {'object_name': 'SupplyPointWarehouseRecord'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'malawi.organization': {
+            'Meta': {'object_name': 'Organization'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'managed_supply_points': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'messagelog.message': {
+            'Meta': {'object_name': 'Message'},
+            'connection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rapidsms.Connection']", 'null': 'True'}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rapidsms.Contact']", 'null': 'True'}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'direction': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        },
+        'rapidsms.backend': {
+            'Meta': {'object_name': 'Backend'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'})
+        },
+        'rapidsms.connection': {
+            'Meta': {'unique_together': "(('backend', 'identity'),)", 'object_name': 'Connection'},
+            'backend': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rapidsms.Backend']"}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rapidsms.Contact']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identity': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'rapidsms.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'commodities': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'reported_by'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['logistics.Product']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '6', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'needs_reminders': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'organization': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['malawi.Organization']", 'null': 'True', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ContactRole']", 'null': 'True', 'blank': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'})
+        },
+        'taggit.tag': {
+            'Meta': {'object_name': 'Tag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'taggit.taggeditem': {
+            'Meta': {'object_name': 'TaggedItem'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_tagged_items'", 'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_items'", 'to': "orm['taggit.Tag']"})
+        }
+    }
+
+    complete_apps = ['logistics']

--- a/static/malawi/config.py
+++ b/static/malawi/config.py
@@ -32,6 +32,38 @@ class Roles(object):
     DISTRICT_ONLY = [DISTRICT_SUPERVISOR, DISTRICT_PHARMACIST, IMCI_COORDINATOR, EPI_COORDINATOR]
     SUPERVISOR_ROLES = [HSA_SUPERVISOR, IN_CHARGE]
 
+
+class BaseLevel(object):
+    """
+    Defined here are the available base levels of reporting. A base level is
+    the location level at which the data was initially reported. For example,
+    when an HSA reports its stock on hand, the base level is HSA. When a facility
+    reports its stock on hand, the base level is FACILITY.
+
+    This is used to keep HSA-reported data and Facility-reported data separate
+    for reporting. For more info, see the usage of the base_level name globally,
+    which is defined on the needed reporting models as well as on the request
+    object for report views.
+
+    These constants are defined as one-character constants to help reduce space usage
+    in the database.
+    """
+    class InvalidBaseLevelException(Exception):
+        pass
+
+    HSA = 'h'
+    FACILITY = 'f'
+
+    @staticmethod
+    def get_base_level_description(base_level, plural=False):
+        if base_level == BaseLevel.HSA:
+            return "HSAs" if plural else "HSA"
+        elif base_level == BaseLevel.FACILITY:
+            return "Facilities" if plural else "Facility"
+        else:
+            raise BaseLevel.InvalidBaseLevelException(base_level)
+
+
 class Operations(object):
     FILL_ORDER = "fill"
     MAKE_TRANSFER = "transfer"


### PR DESCRIPTION
Removes the is_facility flag that's being used to split the data and replaces it with a base_level identifier.
@czue 