### PR TITLE
Update Report Runner for Facility-level data processing

### DIFF
--- a/logistics_project/apps/malawi/management/commands/recompute_consumption.py
+++ b/logistics_project/apps/malawi/management/commands/recompute_consumption.py
@@ -9,6 +9,8 @@ from logistics_project.apps.malawi.warehouse.runner import ReportPeriod,\
     update_consumption, aggregate, update_consumption_times
 from logistics_project.apps.malawi.util import hsa_supply_points_below
 from optparse import make_option
+from static.malawi.config import BaseLevel
+
 
 class Command(LabelCommand):
     
@@ -71,7 +73,7 @@ def recompute(run_record, aggregate_only, hsa_code=None):
             for year, month in months_between(run_record.start, run_record.end):
                 window_date = datetime(year, month, 1)
                 report_period = ReportPeriod(hsa, window_date, run_record.start, run_record.end)
-                update_consumption(report_period)
+                update_consumption(report_period, BaseLevel.HSA)
 
     update_consumption_times(run_record.start_run)
 

--- a/logistics_project/apps/malawi/management/commands/recompute_hsa_warehouse_data.py
+++ b/logistics_project/apps/malawi/management/commands/recompute_hsa_warehouse_data.py
@@ -46,4 +46,4 @@ class Command(LabelCommand):
         warehouse_runner.update_base_level_data(hsa, start, end)
         for parent in hsa.get_parents():
             print 'updating %s' % parent
-            warehouse_runner.update_non_hsa_data(parent, start, end, since=None)
+            warehouse_runner.update_aggregated_data(parent, start, end, since=None)

--- a/logistics_project/apps/malawi/util.py
+++ b/logistics_project/apps/malawi/util.py
@@ -284,3 +284,16 @@ class ConsumptionData(object):
     def average_months_of_stock(self):
         mos = filter(lambda x: x is not None, [p.months_remaining for p in self.ps])
         return sum(mos)/len(mos) if len(mos) else None
+
+
+def get_managed_product_ids(supply_point, base_level):
+    # Note that we .order_by('id') here because default ordering for Product objects
+    # is by name, so if we didn't include this, django also tries to select name in the
+    # raw query which is unnecessary
+    return set(
+        supply_point.commodities_stocked()
+        .filter(type__base_level=base_level)
+        .values_list('id', flat=True)
+        .distinct()
+        .order_by('id')
+    )

--- a/logistics_project/apps/malawi/warehouse/runner.py
+++ b/logistics_project/apps/malawi/warehouse/runner.py
@@ -501,9 +501,6 @@ def update_historical_data():
     If we don't have a record of this supply point being updated, run
     through all historical data and just fill in with zeros.
     """
-    hsa_level_start_date = ReportingRate.objects.filter(base_level=BaseLevel.HSA).order_by('date')[0].date
-    if settings.ENABLE_FACILITY_WORKFLOWS:
-        facility_level_start_date = ReportingRate.objects.filter(base_level=BaseLevel.FACILITY).order_by('date')[0].date
 
     # These models are used by both base levels and have a product attribute
     warehouse_classes_with_product = [
@@ -526,7 +523,7 @@ def update_historical_data():
 
     print 'updating historical data'
     for sp in SupplyPoint.objects.filter(supplypointwarehouserecord__isnull=True):
-        for year, month in months_between(hsa_level_start_date, sp.created_at):
+        for year, month in months_between(BaseLevel.HSA_WAREHOUSE_START_DATE, sp.created_at):
             window_date = datetime(year, month, 1)
 
             for cls in (warehouse_classes_with_product + hsa_only_warehouse_classes_with_product):
@@ -536,7 +533,7 @@ def update_historical_data():
                 _init_with_base_level(cls, sp, window_date, BaseLevel.HSA)
 
         if settings.ENABLE_FACILITY_WORKFLOWS and sp.type_id != SupplyPointCodes.HSA:
-            for year, month in months_between(facility_level_start_date, sp.created_at):
+            for year, month in months_between(BaseLevel.FACILITY_WAREHOUSE_START_DATE, sp.created_at):
                 window_date = datetime(year, month, 1)
 
                 for cls in warehouse_classes_with_product:

--- a/logistics_project/apps/malawi/warehouse/runner.py
+++ b/logistics_project/apps/malawi/warehouse/runner.py
@@ -117,10 +117,10 @@ class MalawiWarehouseRunner(WarehouseRunner):
 
         # rollup aggregates
         if not self.skip_aggregates:
-            self.aggregate_data(start, end, run_record, BaselLevel.HSA)
+            self.aggregate_data(start, end, run_record, BaseLevel.HSA)
 
             if settings.ENABLE_FACILITY_WORKFLOWS:
-                self.aggregate_data(start, end, run_record, BaselLevel.FACILITY)
+                self.aggregate_data(start, end, run_record, BaseLevel.FACILITY)
 
         # run alerts
         if not self.skip_alerts:
@@ -157,7 +157,7 @@ class MalawiWarehouseRunner(WarehouseRunner):
 
     def update_base_level_data(self, supply_point, start, end, all_products=None, base_level=BaseLevel.HSA):
         base_level_is_hsa = (base_level == BaseLevel.HSA)
-        all_products = all_products or Product.objects.filter(type__base_level=base_level)
+        all_products = all_products or get_products(base_level)
         products_managed = get_managed_product_ids(supply_point, base_level)
 
         if not self.skip_current_consumption:
@@ -317,7 +317,7 @@ def update_current_consumption(supply_point, base_level):
     """
     Update the actual consumption data
     """
-    for p in Product.objects.filter(type__base_level=base_level):
+    for p in get_products(base_level):
         
         consumption = CurrentConsumption.objects.get_or_create\
             (supply_point=supply_point, product=p)[0]
@@ -455,7 +455,7 @@ def update_consumption(report_period, base_level, products_managed=None):
     if products_managed is None:
         products_managed = get_managed_product_ids(report_period.supply_point, base_level)
 
-    for p in Product.objects.filter(type__base_level=base_level):
+    for p in get_products(base_level):
         c = CalculatedConsumption.objects.get_or_create(
             supply_point=report_period.supply_point,
             date=report_period.window_date,

--- a/logistics_project/apps/malawi/warehouse/runner.py
+++ b/logistics_project/apps/malawi/warehouse/runner.py
@@ -95,7 +95,7 @@ class MalawiWarehouseRunner(WarehouseRunner):
             hsas = hsas[:self.hsa_limit]
         
         count = len(hsas)
-        all_products = Product.objects.filter(type__code=BaseLevel.HSA)
+        all_products = Product.objects.filter(type__base_level=BaseLevel.HSA)
         if not self.skip_hsas:
             for i, hsa in enumerate(hsas):
                 # process all the hsa-level warehouse tables
@@ -104,7 +104,7 @@ class MalawiWarehouseRunner(WarehouseRunner):
 
         if settings.ENABLE_FACILITY_WORKFLOWS:
             print 'processing facility data'
-            all_products = Product.objects.filter(type__code=BaseLevel.FACILITY)
+            all_products = Product.objects.filter(type__base_level=BaseLevel.FACILITY)
             facilities = SupplyPoint.objects.filter(active=True, type__code=SupplyPointCodes.FACILITY).order_by('id')
             if self.facility_limit:
                 facilities = facilities[:self.facility_limit]
@@ -140,7 +140,7 @@ class MalawiWarehouseRunner(WarehouseRunner):
     def update_base_level_data(self, supply_point, start, end, all_products=None, base_level=BaseLevel.HSA):
         base_level_is_hsa = (base_level == BaseLevel.HSA)
 
-        all_products = all_products or Product.objects.filter(type__code=base_level)
+        all_products = all_products or Product.objects.filter(type__base_level=base_level)
         products_managed = get_managed_product_ids(supply_point, base_level)
 
         if not self.skip_current_consumption:

--- a/logistics_project/apps/malawi/warehouse/warehouse_view.py
+++ b/logistics_project/apps/malawi/warehouse/warehouse_view.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from dimagi.utils.dates import DateSpan
 from django.conf import settings
 from django.contrib import messages
@@ -47,9 +46,9 @@ class MalawiWarehouseView(ReportView):
         be a suitable option.
         """
         if request.base_level_is_hsa:
-            return datetime(2011, 6, 1)
+            return config.BaseLevel.HSA_WAREHOUSE_START_DATE
         elif request.base_level_is_facility:
-            return datetime(2016, 10, 1)
+            return config.BaseLevel.FACILITY_WAREHOUSE_START_DATE
         else:
             raise config.BaseLevel.InvalidBaseLevelException(request.base_level)
 

--- a/static/malawi/config.py
+++ b/static/malawi/config.py
@@ -1,4 +1,4 @@
-
+from datetime import datetime
 
 
 HSA = "hsa"
@@ -56,6 +56,9 @@ class BaseLevel(object):
 
     HSA = 'h'
     FACILITY = 'f'
+
+    HSA_WAREHOUSE_START_DATE = datetime(2011, 6, 1)
+    FACILITY_WAREHOUSE_START_DATE = datetime(2016, 10, 1)
 
     @staticmethod
     def get_base_level_description(base_level, plural=False):


### PR DESCRIPTION
Updates the Malawi warehouse runner to be completely compatible with processing both hsa-level and facility-level data concurrently, and populates all the needed models for the facility-level reports. Some models aren't needed by the facility-level reports and those are only populated for hsa-level data.

Before we enable the facility workflows flag though, I'll need to do a couple migrations, including creating all the new products as well as assigning managed products to all the existing facility-level contacts who can report stock on hand.

This is safe to run as is in prod (without the new products created), also safe to run with the new products added and the facility enabled flag turned off, and safe to run with the flag turned on once the two migrations I mentioned above are completed.

@czue 