### PR TITLE
Fix shared logistics handlers

### DIFF
--- a/logistics_project/apps/malawi/handlers/help.py
+++ b/logistics_project/apps/malawi/handlers/help.py
@@ -5,10 +5,10 @@ from django.utils.translation import ugettext as _
 from rapidsms.contrib.handlers.handlers.keyword import KeywordHandler
 from logistics.models import Product
 from logistics.util import config
-from logistics.handlers import logistics_keyword
+
 
 class Help(KeywordHandler):
-    keyword = logistics_keyword("help")
+    keyword = "help"
 
 
     def help(self):

--- a/logistics_project/apps/malawi/handlers/help.py
+++ b/logistics_project/apps/malawi/handlers/help.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4 encoding=utf-8
-
-from django.utils.translation import ugettext as _
+from django.utils.datastructures import SortedDict
 from rapidsms.contrib.handlers.handlers.keyword import KeywordHandler
+from logistics.decorators import logistics_contact_required
 from logistics.models import Product
 from logistics.util import config
 
@@ -10,30 +10,49 @@ from logistics.util import config
 class Help(KeywordHandler):
     keyword = "help"
 
-
+    @logistics_contact_required()
     def help(self):
         self.respond(config.Messages.HELP_TEXT)
 
+    @logistics_contact_required()
     def handle(self, text):
+        is_hsa = (
+            self.msg.logistics_contact.supply_point and
+            self.msg.logistics_contact.supply_point.type_id == config.SupplyPointCodes.HSA
+        )
         topic = text.strip().lower()
+
         if topic == 'stock':
-            self.respond(_("Please send your receipts in the format ' <Commodity code> <stock on hand > . <quantity received>'"))
-        elif topic == 'stop':
-            self.respond(_("Text 'stop' to stop receiving text message reminders."))
-        elif topic == 'start':
-            self.respond(_("Text 'start' to get text message reminders every week to submit your stock reports."))
+            self.respond(config.Messages.SOH_HELP_MESSAGE)
         elif 'code' in topic:
-            codes = [c.sms_code for c in Product.objects.all().order_by('sms_code')]
-            self.respond("Available commodity codes: %(codes)s", codes=", ".join(codes))
+            products = Product.objects.filter(is_active=True).select_related('type').order_by("type__id", "sms_code")
+
+            # Only show HSA-level products to HSAs; show all products to everyone else
+            if is_hsa:
+                products = products.filter(type__base_level=config.BaseLevel.HSA)
+
+            grouped_codes = SortedDict()
+            for p in products:
+                if p.type.name not in grouped_codes:
+                    grouped_codes[p.type.name] = []
+                grouped_codes[p.type.name].append(p.sms_code.lower())
+
+            messages = []
+            for type_name, codes in grouped_codes.iteritems():
+                messages.append("%s codes: %s" % (type_name, " ".join(codes)))
+
+            self.respond("; ".join(messages))
         else:
             try:
-                p = Product.objects.get(sms_code=topic)
-                msg = "%s is the commodity code for %s" % (topic, p.name)
-                if p.units:
-                    msg = msg + " (%s)" % p.units
-                if p.description:
-                    if p.description not in p.name:
-                        msg = msg + " %s" % p.description
-                self.respond(msg)
+                if is_hsa:
+                    p = Product.objects.get(sms_code=topic, is_active=True, type__base_level=config.BaseLevel.HSA)
+                else:
+                    p = Product.objects.get(sms_code=topic, is_active=True)
             except Product.DoesNotExist:
                 self.respond(config.Messages.HELP_TEXT)
+
+            msg = "%s is the code for %s product %s" % (topic, p.type.name, p.name)
+            if p.units:
+                msg = msg + " (%s)" % p.units
+
+            self.respond(msg)

--- a/logistics_project/apps/malawi/handlers/help.py
+++ b/logistics_project/apps/malawi/handlers/help.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# vim: ai ts=4 sts=4 et sw=4 encoding=utf-8
+
+from django.utils.translation import ugettext as _
+from rapidsms.contrib.handlers.handlers.keyword import KeywordHandler
+from logistics.models import Product
+from logistics.util import config
+from logistics.handlers import logistics_keyword
+
+class Help(KeywordHandler):
+    keyword = logistics_keyword("help")
+
+
+    def help(self):
+        self.respond(config.Messages.HELP_TEXT)
+
+    def handle(self, text):
+        topic = text.strip().lower()
+        if topic == 'stock':
+            self.respond(_("Please send your receipts in the format ' <Commodity code> <stock on hand > . <quantity received>'"))
+        elif topic == 'stop':
+            self.respond(_("Text 'stop' to stop receiving text message reminders."))
+        elif topic == 'start':
+            self.respond(_("Text 'start' to get text message reminders every week to submit your stock reports."))
+        elif 'code' in topic:
+            codes = [c.sms_code for c in Product.objects.all().order_by('sms_code')]
+            self.respond("Available commodity codes: %(codes)s", codes=", ".join(codes))
+        else:
+            try:
+                p = Product.objects.get(sms_code=topic)
+                msg = "%s is the commodity code for %s" % (topic, p.name)
+                if p.units:
+                    msg = msg + " (%s)" % p.units
+                if p.description:
+                    if p.description not in p.name:
+                        msg = msg + " %s" % p.description
+                self.respond(msg)
+            except Product.DoesNotExist:
+                self.respond(config.Messages.HELP_TEXT)

--- a/logistics_project/apps/malawi/handlers/receipts.py
+++ b/logistics_project/apps/malawi/handlers/receipts.py
@@ -11,7 +11,6 @@ from logistics.models import ProductReportsHelper, StockRequest, StockTransfer, 
 from logistics.decorators import logistics_contact_and_permission_required
 from logistics.const import Reports
 from logistics.util import config, ussd_msg_response
-from logistics.handlers import logistics_keyword
 from rapidsms.conf import settings
 from rapidsms.contrib.messagelog.models import Message
 
@@ -21,7 +20,7 @@ class ReceiptHandler(KeywordHandler, TaggingHandler):
     Allows SMS reporters to send in "rec jd 10 mc 30" to report 10 jadelle and 30 male condoms received
     """
 
-    keyword = logistics_keyword("rec|receipts|received")
+    keyword = "rec|receipts|received"
 
     def help(self):
         self.respond(_("Please send in information about your receipts in the format 'rec <product> <amount> <product> <amount>...'"))

--- a/logistics_project/apps/malawi/handlers/receipts.py
+++ b/logistics_project/apps/malawi/handlers/receipts.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# vim: ai ts=4 sts=4 et sw=4 encoding=utf-8
+from datetime import datetime, timedelta
+
+from django.utils.translation import ugettext as _
+from logistics.exceptions import TooMuchStockError
+from logistics.validators import check_max_levels, get_max_level_function
+from rapidsms.contrib.handlers.handlers.keyword import KeywordHandler
+from rapidsms.contrib.handlers.handlers.tagging import TaggingHandler
+from logistics.models import ProductReportsHelper, StockRequest, StockTransfer, ProductReport
+from logistics.decorators import logistics_contact_and_permission_required
+from logistics.const import Reports
+from logistics.util import config, ussd_msg_response
+from logistics.handlers import logistics_keyword
+from rapidsms.conf import settings
+from rapidsms.contrib.messagelog.models import Message
+
+
+class ReceiptHandler(KeywordHandler, TaggingHandler):
+    """
+    Allows SMS reporters to send in "rec jd 10 mc 30" to report 10 jadelle and 30 male condoms received
+    """
+
+    keyword = logistics_keyword("rec|receipts|received")
+
+    def help(self):
+        self.respond(_("Please send in information about your receipts in the format 'rec <product> <amount> <product> <amount>...'"))
+
+    @logistics_contact_and_permission_required(config.Operations.REPORT_RECEIPT)
+    def handle(self, text):
+        dupes = Message.objects.filter(direction="I",
+                                       connection=self.msg.connection,
+                                       text__iexact=self.msg.raw_text).exclude(pk=self.msg.logger_msg.pk)
+        if settings.LOGISTICS_IGNORE_DUPE_RECEIPTS_WITHIN:
+            dupe_ignore_threshold = datetime.utcnow() - timedelta(seconds=settings.LOGISTICS_IGNORE_DUPE_RECEIPTS_WITHIN)
+            ignore = dupes.filter(date__gte=dupe_ignore_threshold)
+            if ignore.count() and ProductReport.objects.filter(message__in=dupes).count():
+                return True
+
+        # at the end of your receipt message you can write:
+        # 'from xxx' to indicate the source of the supplies.
+        # this is used in the stock transfer workflow
+        # TODO: less brittle parsing
+        if "from" in text.lower().split():
+            splittext = text.lower().split()
+            text = " ".join(splittext[:splittext.index("from")])
+            supplier = " ".join(splittext[splittext.index("from") + 1:])
+        else:
+            supplier = None
+        
+        # parse the report and save as normal receipt
+        stock_report = ProductReportsHelper(self.msg.logistics_contact.supply_point,
+                                            Reports.REC, self.msg.logger_msg)
+        stock_report.parse(text)
+        # check max stock levels
+        max_level_function = get_max_level_function()
+        if max_level_function:
+
+            try:
+                max_level_function(stock_report)
+            except TooMuchStockError, e:
+                # bit of a hack, also check if there was a recent message
+                # that matched this and if so force it through
+                override_threshold = datetime.utcnow() - timedelta(seconds=60*60*4)
+                override = dupes.filter(date__gte=override_threshold)
+                if override.count() == 0:
+                    self.respond(config.Messages.TOO_MUCH_STOCK % {
+                        'keyword': self.msg.text.split()[0],
+                        'req': e.amount,
+                        'prod': e.product,
+                        'max': e.max,
+                    })
+                    return True
+
+        stock_report.save()
+
+        # Close pending requests. This logic only applies if you are using the
+        # StockRequest workflow, but should not break anything if you are not
+        StockRequest.close_pending_from_receipt_report(stock_report, self.msg.logistics_contact)
+        
+        # fill in transfers, if there were any
+        if supplier is not None:
+            StockTransfer.create_from_receipt_report(stock_report, supplier)
+            self.respond(_(config.Messages.RECEIPT_FROM_CONFIRM), products=" ".join(stock_report.reported_products()).strip(),
+                         supplier=supplier)
+        else:
+            self.respond(_(config.Messages.RECEIPT_CONFIRM), products=" ".join(stock_report.reported_products()).strip())
+
+    def respond(self, template=None, **kwargs):
+        self.add_default_tags()
+        self.add_tags(kwargs.get("tags", []))
+        return ussd_msg_response(self.msg, template, **kwargs)

--- a/logistics_project/apps/malawi/tests/facility/receipts.py
+++ b/logistics_project/apps/malawi/tests/facility/receipts.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+from logistics.models import ProductStock, SupplyPoint, ProductReport, Product
+from logistics_project.apps.malawi.tests.facility.base import MalawiFacilityLevelTestBase
+from rapidsms.contrib.messagelog.models import Message
+from static.malawi import config
+
+
+class MalawiTestFacilityReceipts(MalawiFacilityLevelTestBase):
+
+    def setUp(self):
+        super(MalawiTestFacilityReceipts, self).setUp()
+        ProductReport.objects.all().delete()
+
+    def testReceiptsNormal(self):
+        self._setup_users()
+        self.runScript("""
+           16175551000 > rec bc 100 sa 2
+           16175551000 < %(response)s
+        """ % {
+            "response": config.Messages.RECEIPT_CONFIRM % {"products": "sa bc"}
+        })
+        self.assertEqual(2, ProductReport.objects.count())
+        bc = ProductStock.objects.get(product__sms_code="bc", supply_point__code="2616")
+        sa = ProductStock.objects.get(product__sms_code="sa", supply_point__code="2616")
+        self.assertEqual(100, bc.quantity)
+        self.assertEqual(2, sa.quantity)
+        self.runScript("""
+           16175551000 > rec bc 100 sa 3
+           16175551000 < %(response)s
+        """ % {
+            "response": config.Messages.RECEIPT_CONFIRM % {"products": "sa bc"}
+        })
+        self.assertEqual(4, ProductReport.objects.count())
+        bc = ProductStock.objects.get(product__sms_code="bc", supply_point__code="2616")
+        sa = ProductStock.objects.get(product__sms_code="sa", supply_point__code="2616")
+        self.assertEqual(200, bc.quantity)
+        self.assertEqual(5, sa.quantity)
+
+    def testReceiptsIgnoreDupes(self):
+        self._setup_users()
+        self.runScript("""
+           16175551000 > rec bc 100 sa 2
+           16175551000 < %(response)s
+        """ % {
+            "response": config.Messages.RECEIPT_CONFIRM % {"products": "sa bc"}
+        })
+        self.assertEqual(2, ProductReport.objects.count())
+        bc = ProductStock.objects.get(product__sms_code="bc", supply_point__code="2616")
+        sa = ProductStock.objects.get(product__sms_code="sa", supply_point__code="2616")
+        self.assertEqual(100, bc.quantity)
+        self.assertEqual(2, sa.quantity)
+        outbound_message_count = Message.objects.filter(direction='O').count()
+
+        self.runScript("16175551000 > rec bc 100 sa 2")
+        # ensure no new outbound message was sent
+        self.assertEqual(outbound_message_count, Message.objects.filter(direction='O').count())
+        self.assertEqual(2, ProductReport.objects.count())
+        bc = ProductStock.objects.get(product__sms_code="bc", supply_point__code="2616")
+        sa = ProductStock.objects.get(product__sms_code="sa", supply_point__code="2616")
+        self.assertEqual(100, bc.quantity)
+        self.assertEqual(2, sa.quantity)
+
+    def testHSALevelProduct(self):
+        self._setup_users()
+        product_code = Product.objects.filter(type__base_level=config.BaseLevel.HSA)[0].sms_code
+        self.runScript("""
+            16175551000 > rec %(product_code)s 20
+            16175551000 < %(error)s
+        """ % {
+            "product_code": product_code,
+            "error": config.Messages.INVALID_PRODUCT_BASE_LEVEL % {"product_code": product_code},
+        })

--- a/logistics_project/deployments/malawi/settings_base.py
+++ b/logistics_project/deployments/malawi/settings_base.py
@@ -254,3 +254,4 @@ SOUTH_MIGRATION_MODULES = {
 # data warehouse config
 WAREHOUSE_RUNNER = 'logistics_project.apps.malawi.warehouse.runner.MalawiWarehouseRunner'
 ENABLE_FACILITY_WORKFLOWS = False
+LOGISTICS_USE_DEFAULT_HANDLERS = False

--- a/static/malawi/config.py
+++ b/static/malawi/config.py
@@ -349,9 +349,9 @@ class Messages(object):
     NUMBER_OF_SUPPLY_POINTS = "Number of HSAs"
     
     # response to 'help'
-    HELP_TEXT = "Text 'help stock' for help on the format of stock reports; " + \
-                "'help codes' for a list of commodity codes; " + \
-                "'help start' or 'help stop' to start and stop reminders."
+    HELP_TEXT = ("Text 'help stock' for help on the format of stock reports; "
+                 "'help codes' for a list of product codes; "
+                 "'help [product code]' for a product's description")
 
     FRIDGE_BROKEN_NO_GAS = "no gas"
     FRIDGE_BROKEN_POWER_FAILURE = "power failure"


### PR DESCRIPTION
This PR copies the shared logistics handlers into the malawi handlers directory and then updates them accordingly:

receipts - this handler was updated to validate the product base level in the products reported

help - this handler was displaying info for ghana; it's been updated to show malawi info and also avoids showing non-HSA products to HSAs

status - this handler hasn't ever been invoked by any inbound message in the message log; it was left out

stop - this handler only seems to have applied to ghana (all it did was update Contact.needs_reminders which isn't used by malawi as far as i can tell); it was left out

@czue 