### PR TITLE
Don't load static data on deploy

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -70,10 +70,7 @@ def _malawi_shared():
     env.db_cleanup = False
     env.stop_start = True
     env.branch = "malawi-dev"
-    def malawi_extras():
-        run("python manage.py malawi_init")
-        run("python manage.py loaddata ../deploy/malawi/initial_data.json")
-    env.extras = malawi_extras
+
 
 def malawi():
     """


### PR DESCRIPTION
It seems like the static data being loaded by these processes (like the product list) wasn't being kept up to date in the repo so we could have eventually been overwriting changes we made to products or other data by running this on each deploy. I checked against the oldest db backup I could find (at the end of 2015) and it didn't have any differences in this static data, but we should probably stop loading static data on deploy since it's not an obvious thing and could easily lead to confusion down the road.

@czue 