### PR TITLE
Handle unknown products

### DIFF
--- a/logistics_project/apps/malawi/handlers/abstract/stockreport.py
+++ b/logistics_project/apps/malawi/handlers/abstract/stockreport.py
@@ -73,7 +73,7 @@ class StockReportBaseHandler(RecordResponseHandler):
                 'prod': e.product,
                 'max': e.max,
             })
-        except config.BaseLevel.InvalidProductBaseLevelException as e2:
-            self.respond(config.Messages.INVALID_PRODUCT_BASE_LEVEL, product_code=e2.product_code)
+        except config.BaseLevel.InvalidProductsException as e2:
+            self.respond(config.Messages.INVALID_PRODUCTS, product_codes=e2.product_codes_str)
         except RefrigeratorMalfunction.RefrigeratorNotWorkingException:
             self.respond(config.Messages.FRIDGE_BROKEN)

--- a/logistics_project/apps/malawi/handlers/receipts.py
+++ b/logistics_project/apps/malawi/handlers/receipts.py
@@ -58,8 +58,8 @@ class ReceiptHandler(KeywordHandler, TaggingHandler):
         # Validate base level of products
         try:
             get_base_level_validator(self.base_level)(stock_report)
-        except config.BaseLevel.InvalidProductBaseLevelException as e:
-            self.respond(config.Messages.INVALID_PRODUCT_BASE_LEVEL, product_code=e.product_code)
+        except config.BaseLevel.InvalidProductsException as e:
+            self.respond(config.Messages.INVALID_PRODUCTS, product_codes=e.product_codes_str)
             return
 
         # check max stock levels

--- a/logistics_project/apps/malawi/handlers/receipts.py
+++ b/logistics_project/apps/malawi/handlers/receipts.py
@@ -53,7 +53,7 @@ class ReceiptHandler(KeywordHandler, TaggingHandler):
         # parse the report and save as normal receipt
         stock_report = ProductReportsHelper(self.msg.logistics_contact.supply_point,
                                             Reports.REC, self.msg.logger_msg)
-        stock_report.parse(text)
+        stock_report.newparse(text)
 
         # Validate base level of products
         try:

--- a/logistics_project/apps/malawi/handlers/report.py
+++ b/logistics_project/apps/malawi/handlers/report.py
@@ -60,8 +60,8 @@ class ReportRegistrationHandler(KeywordHandler):
                 self.msg.logger_msg,
                 additional_validation=get_base_level_validator(self.base_level)
             )
-        except config.BaseLevel.InvalidProductBaseLevelException as e:
-            self.respond(config.Messages.INVALID_PRODUCT_BASE_LEVEL, product_code=e.product_code)
+        except config.BaseLevel.InvalidProductsException as e:
+            self.respond(config.Messages.INVALID_PRODUCTS, product_codes=e.product_codes_str)
             return
 
         requests = StockRequest.create_from_report(stock_report, self.hsa)
@@ -87,8 +87,8 @@ class ReportRegistrationHandler(KeywordHandler):
                 self.msg.logger_msg,
                 additional_validation=get_base_level_validator(self.base_level)
             )
-        except config.BaseLevel.InvalidProductBaseLevelException as e:
-            self.respond(config.Messages.INVALID_PRODUCT_BASE_LEVEL, product_code=e.product_code)
+        except config.BaseLevel.InvalidProductsException as e:
+            self.respond(config.Messages.INVALID_PRODUCTS, product_codes=e.product_codes_str)
             return
 
         requests = StockRequest.create_from_report(stock_report, self.hsa)
@@ -114,8 +114,8 @@ class ReportRegistrationHandler(KeywordHandler):
                 self.msg.logger_msg,
                 additional_validation=get_base_level_validator(self.base_level)
             )
-        except config.BaseLevel.InvalidProductBaseLevelException as e:
-            self.respond(config.Messages.INVALID_PRODUCT_BASE_LEVEL, product_code=e.product_code)
+        except config.BaseLevel.InvalidProductsException as e:
+            self.respond(config.Messages.INVALID_PRODUCTS, product_codes=e.product_codes_str)
             return
 
         StockRequest.close_pending_from_receipt_report(stock_report, self.hsa)
@@ -147,8 +147,8 @@ class ReportRegistrationHandler(KeywordHandler):
                     self.msg.logger_msg,
                     additional_validation=get_base_level_validator(self.base_level)
                 )
-            except config.BaseLevel.InvalidProductBaseLevelException as e:
-                self.respond(config.Messages.INVALID_PRODUCT_BASE_LEVEL, product_code=e.product_code)
+            except config.BaseLevel.InvalidProductsException as e:
+                self.respond(config.Messages.INVALID_PRODUCTS, product_codes=e.product_codes_str)
                 return
 
             transfers = StockTransfer.create_from_transfer_report(stock_report, hsa.supply_point)

--- a/logistics_project/apps/malawi/handlers/transfer.py
+++ b/logistics_project/apps/malawi/handlers/transfer.py
@@ -55,8 +55,8 @@ class TransferHandler(KeywordHandler):
                     self.msg.logger_msg,
                     additional_validation=get_base_level_validator(self.base_level)
                 )
-            except config.BaseLevel.InvalidProductBaseLevelException as e:
-                self.respond(config.Messages.INVALID_PRODUCT_BASE_LEVEL, product_code=e.product_code)
+            except config.BaseLevel.InvalidProductsException as e:
+                self.respond(config.Messages.INVALID_PRODUCTS, product_codes=e.product_codes_str)
                 return
 
             StockTransfer.create_from_transfer_report(stock_report, supply_point)

--- a/logistics_project/apps/malawi/tests/facility/receipts.py
+++ b/logistics_project/apps/malawi/tests/facility/receipts.py
@@ -68,5 +68,14 @@ class MalawiTestFacilityReceipts(MalawiFacilityLevelTestBase):
             16175551000 < %(error)s
         """ % {
             "product_code": product_code,
-            "error": config.Messages.INVALID_PRODUCT_BASE_LEVEL % {"product_code": product_code},
+            "error": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
+        })
+
+    def testNonExistentProduct(self):
+        self._setup_users()
+        self.runScript("""
+            16175551000 > rec uvw 10 xyz 20
+            16175551000 < %(error)s
+        """ % {
+            "error": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
         })

--- a/logistics_project/apps/malawi/tests/facility/stockonhand.py
+++ b/logistics_project/apps/malawi/tests/facility/stockonhand.py
@@ -38,7 +38,19 @@ class TestFacilityLevelStockOnHandMalawi(MalawiFacilityLevelTestBase):
             """ % {
                 "keyword": keyword,
                 "product_code": product_code,
-                "error": config.Messages.INVALID_PRODUCT_BASE_LEVEL % {"product_code": product_code},
+                "error": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
+            }
+            self.runScript(a)
+
+    def testReportingNonExistentProduct(self):
+        create_manager(self, "16175551000", "wendy", role=config.Roles.IN_CHARGE, supply_point_code="2616")
+        for keyword in ("soh", "eo"):
+            a = """
+                16175551000 > %(keyword)s uvw 10 xyz 20
+                16175551000 < %(error)s
+            """ % {
+                "keyword": keyword,
+                "error": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
             }
             self.runScript(a)
 

--- a/logistics_project/apps/malawi/tests/facility/transfer.py
+++ b/logistics_project/apps/malawi/tests/facility/transfer.py
@@ -131,3 +131,23 @@ class TestFacilityLevelTransfer(MalawiFacilityLevelTestBase):
             self.assertEqual(transfer.receiver, ic.supply_point)
             self.assertEqual(transfer.status, StockTransferStatus.CONFIRMED)
             self.assertEqual(transfer.initiated_on, None)
+
+    def testHSALevelProduct(self):
+        ic1 = self._setup_users()[0]
+        product_code = Product.objects.filter(type__base_level=config.BaseLevel.HSA)[0].sms_code
+        self.runScript("""
+            16175551000 > give 2601 %(product_code)s 20
+            16175551000 < %(error)s
+        """ % {
+            "product_code": product_code,
+            "error": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
+        })
+
+    def testNonExistentProduct(self):
+        ic1 = self._setup_users()[0]
+        self.runScript("""
+            16175551000 > give 2601 uvw 10 xyz 20
+            16175551000 < %(error)s
+        """ % {
+            "error": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
+        })

--- a/logistics_project/apps/malawi/tests/receipts.py
+++ b/logistics_project/apps/malawi/tests/receipts.py
@@ -63,5 +63,14 @@ class MalawiTestReceipts(MalawiTestBase):
             16175551000 < %(error)s
         """ % {
             "product_code": product_code,
-            "error": config.Messages.INVALID_PRODUCT_BASE_LEVEL % {"product_code": product_code},
+            "error": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
+        })
+
+    def testNonExistentProduct(self):
+        create_hsa(self, "16175551000", "wendy", products="co la lb zi")
+        self.runScript("""
+            16175551000 > rec uvw 10 xyz 20
+            16175551000 < %(error)s
+        """ % {
+            "error": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
         })

--- a/logistics_project/apps/malawi/tests/report.py
+++ b/logistics_project/apps/malawi/tests/report.py
@@ -27,7 +27,7 @@ class TestReport(MalawiTestBase):
                 16175551002 < %(response)s
             """ % {
                 "product_code": product_code,
-                "response": config.Messages.INVALID_PRODUCT_BASE_LEVEL % {"product_code": product_code},
+                "response": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
             }
         )
 
@@ -36,7 +36,7 @@ class TestReport(MalawiTestBase):
                 16175551002 < %(response)s
             """ % {
                 "product_code": product_code,
-                "response": config.Messages.INVALID_PRODUCT_BASE_LEVEL % {"product_code": product_code},
+                "response": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
             }
         )
 
@@ -45,7 +45,7 @@ class TestReport(MalawiTestBase):
                 16175551002 < %(response)s
             """ % {
                 "product_code": product_code,
-                "response": config.Messages.INVALID_PRODUCT_BASE_LEVEL % {"product_code": product_code},
+                "response": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
             }
         )
 
@@ -54,7 +54,44 @@ class TestReport(MalawiTestBase):
                 16175551002 < %(response)s
             """ % {
                 "product_code": product_code,
-                "response": config.Messages.INVALID_PRODUCT_BASE_LEVEL % {"product_code": product_code},
+                "response": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
+            }
+        )
+
+    def testNonExistentProduct(self):
+        create_hsa(self, "16175551000", "giver")
+        create_hsa(self, "16175551001", "receiver", "2")
+        create_hsa(self, "16175551002", "reporter", "3")
+
+        self.runScript(
+            """ 16175551002 > report 261601 give 261602 uvw 10 xyz 20
+                16175551002 < %(response)s
+            """ % {
+                "response": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
+            }
+        )
+
+        self.runScript(
+            """ 16175551002 > report 261601 soh uvw 10 xyz 20
+                16175551002 < %(response)s
+            """ % {
+                "response": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
+            }
+        )
+
+        self.runScript(
+            """ 16175551002 > report 261601 eo uvw 10 xyz 20
+                16175551002 < %(response)s
+            """ % {
+                "response": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
+            }
+        )
+
+        self.runScript(
+            """ 16175551002 > report 261601 rec uvw 10 xyz 20
+                16175551002 < %(response)s
+            """ % {
+                "response": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
             }
         )
 

--- a/logistics_project/apps/malawi/tests/stockonhand.py
+++ b/logistics_project/apps/malawi/tests/stockonhand.py
@@ -413,6 +413,18 @@ class TestStockOnHandMalawi(MalawiTestBase):
             """ % {
                 "keyword": keyword,
                 "product_code": product_code,
-                "error": config.Messages.INVALID_PRODUCT_BASE_LEVEL % {"product_code": product_code},
+                "error": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
+            }
+            self.runScript(a)
+
+    def testReportingNonExistentProduct(self):
+        hsa = create_hsa(self, "16175551000", "wendy", products="co la lb zi")
+        for keyword in ("soh", "eo"):
+            a = """
+                16175551000 > %(keyword)s uvw 10 xyz 20
+                16175551000 < %(error)s
+            """ % {
+                "keyword": keyword,
+                "error": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
             }
             self.runScript(a)

--- a/logistics_project/apps/malawi/tests/transfer.py
+++ b/logistics_project/apps/malawi/tests/transfer.py
@@ -98,3 +98,25 @@ class TestTransfer(MalawiTestBase):
             self.assertEqual(SupplyPoint.objects.get(code="261601"), transfer.receiver)
             self.assertEqual(StockTransferStatus.CONFIRMED, transfer.status)
             self.assertEqual(None, transfer.initiated_on)
+
+    def testFacilityLevelProduct(self):
+        create_hsa(self, "16175551000", "wendy", products="zi")
+        create_hsa(self, "16175551001", "steve", id="2", products="zi")
+        product_code = Product.objects.filter(type__base_level=config.BaseLevel.FACILITY)[0].sms_code
+        self.runScript("""
+            16175551000 > give 261602 %(product_code)s 20
+            16175551000 < %(error)s
+        """ % {
+            "product_code": product_code,
+            "error": config.Messages.INVALID_PRODUCTS % {"product_codes": product_code},
+        })
+
+    def testNonExistentProduct(self):
+        create_hsa(self, "16175551000", "wendy", products="zi")
+        create_hsa(self, "16175551001", "steve", id="2", products="zi")
+        self.runScript("""
+            16175551000 > give 261602 uvw 10 xyz 20
+            16175551000 < %(error)s
+        """ % {
+            "error": config.Messages.INVALID_PRODUCTS % {"product_codes": "uvw,xyz"},
+        })

--- a/static/malawi/config.py
+++ b/static/malawi/config.py
@@ -80,6 +80,7 @@ class BaseLevel(object):
         def __init__(self, product_codes, *args, **kwargs):
             super(BaseLevel.InvalidProductsException, self).__init__(*args, **kwargs)
             self.product_codes = product_codes
+            self.product_codes.sort()
 
         @property
         def product_codes_str(self):

--- a/static/malawi/config.py
+++ b/static/malawi/config.py
@@ -72,10 +72,18 @@ class BaseLevel(object):
     class InvalidSupervisorLevelException(Exception):
         pass
 
-    class InvalidProductBaseLevelException(Exception):
-        def __init__(self, product_code, *args, **kwargs):
-            super(BaseLevel.InvalidProductBaseLevelException, self).__init__(*args, **kwargs)
-            self.product_code = product_code
+    class InvalidProductsException(Exception):
+        """
+        Can be raised when product(s) don't exist or don't match the expected base level.
+        Expected to be passed a list of product codes that are invalid.
+        """
+        def __init__(self, product_codes, *args, **kwargs):
+            super(BaseLevel.InvalidProductsException, self).__init__(*args, **kwargs)
+            self.product_codes = product_codes
+
+        @property
+        def product_codes_str(self):
+            return ",".join(self.product_codes)
 
     HSA = 'h'
     FACILITY = 'f'
@@ -404,8 +412,8 @@ class Messages(object):
 
     TRANSFER_RESPONSE_TO_DISTRICT = "Thank you, %(facility)s has been notified of the advised transfer."
 
-    INVALID_PRODUCT_BASE_LEVEL = ("Your request could not be processed because %(product_code)s is not a valid "
-        "product. Please try again.")
+    INVALID_PRODUCTS = ("The following products are not valid: %(product_codes)s. Please fix and send again. "
+        "Send 'help' for help with product codes.")
 
     FRIDGE_BROKEN = ("Our system shows your refrigerator is not working. If it has been fixed, please respond "
         "with 'rf' and then try your request again.")


### PR DESCRIPTION
Gracefully handles when products aren't found in the stock on hand, emergency order, receipts, transfer, and report handlers.

Previously either no error message was sent in response or the [GENERIC_ERROR](https://github.com/dimagi/logistics/blob/11e04f833d30357832695afd7089ba8fed5875d4/static/malawi/config.py#L340) was sent in response.

Goes with https://github.com/dimagi/rapidsms-logistics/pull/44

@czue 