### PR TITLE
Introduce Zone Level

### DIFF
--- a/logistics_project/apps/malawi/handlers/managers.py
+++ b/logistics_project/apps/malawi/handlers/managers.py
@@ -16,7 +16,7 @@ class ManagerRegistrationHandler(RegistrationBaseHandler):
         self.respond(config.Messages.MANAGER_HELP)
 
     def valid_roles(self):
-        return config.Roles.FACILITY_ONLY + config.Roles.DISTRICT_ONLY + config.Roles.COUNTRY_ONLY
+        return config.Roles.FACILITY_ONLY + config.Roles.DISTRICT_ONLY + config.Roles.ZONE_ONLY
 
     def respond_role_wrong_level(self, role):
         self.respond(config.Messages.ROLE_WRONG_LEVEL, role=role.name, level=self.supply_point.location.type.name)
@@ -39,7 +39,7 @@ class ManagerRegistrationHandler(RegistrationBaseHandler):
             self.respond_unknown_role(role.code)
             return
 
-        if self.supply_point.location.type.name != config.LocationCodes.COUNTRY and role.code in config.Roles.COUNTRY_ONLY:
+        if self.supply_point.location.type.name != config.LocationCodes.ZONE and role.code in config.Roles.ZONE_ONLY:
             self.respond_role_wrong_level(role)
             return
 
@@ -67,8 +67,9 @@ class ManagerRegistrationHandler(RegistrationBaseHandler):
         self.msg.connection.contact = contact
         self.msg.connection.save()
 
-        if role.code in config.Roles.COUNTRY_ONLY:
-            self.respond(config.Messages.REGISTRATION_COUNTRY_CONFIRM, contact_name=contact.name, role=role.name)
+        if role.code in config.Roles.ZONE_ONLY:
+            self.respond(config.Messages.REGISTRATION_ZONE_CONFIRM, sp_name=self.supply_point.name,
+                         contact_name=contact.name, role=contact.role.name)
         elif role.code in config.Roles.DISTRICT_ONLY:
             self.respond(_(config.Messages.REGISTRATION_DISTRICT_CONFIRM), sp_name=self.supply_point.name,
                          contact_name=contact.name, role=contact.role.name)

--- a/logistics_project/apps/malawi/handlers/orderstockout.py
+++ b/logistics_project/apps/malawi/handlers/orderstockout.py
@@ -80,12 +80,12 @@ class OrderStockoutHandler(OrderResponseBaseHandler):
             if stockouts.count() > 0:
                 _message_supervisors(
                     config.Messages.UNABLE_RESTOCK_STOCKOUT_DISTRICT_ESCALATION if self.base_level_is_hsa
-                    else config.Messages.UNABLE_RESTOCK_STOCKOUT_REGION_ESCALATION
+                    else config.Messages.UNABLE_RESTOCK_STOCKOUT_ZONE_ESCALATION
                 )
             else:
                 _message_supervisors(
                     config.Messages.UNABLE_RESTOCK_EO_DISTRICT_ESCALATION if self.base_level_is_hsa
-                    else config.Messages.UNABLE_RESTOCK_EO_REGION_ESCALATION
+                    else config.Messages.UNABLE_RESTOCK_EO_ZONE_ESCALATION
                 )
         else:
             self.respond(
@@ -100,7 +100,7 @@ class OrderStockoutHandler(OrderResponseBaseHandler):
 
             _message_supervisors(
                 config.Messages.UNABLE_RESTOCK_NORMAL_DISTRICT_ESCALATION if self.base_level_is_hsa
-                else config.Messages.UNABLE_RESTOCK_NORMAL_REGION_ESCALATION
+                else config.Messages.UNABLE_RESTOCK_NORMAL_ZONE_ESCALATION
             )
 
             

--- a/logistics_project/apps/malawi/handlers/transfer_epi.py
+++ b/logistics_project/apps/malawi/handlers/transfer_epi.py
@@ -9,7 +9,7 @@ from rapidsms.contrib.handlers.handlers.keyword import KeywordHandler
 from rapidsms.models import Contact
 
 
-class RefrigeratorMalfunctionHandler(KeywordHandler):
+class AdviseEPITransferHandler(KeywordHandler):
     keyword = "transfer"
 
     def help(self):
@@ -24,7 +24,7 @@ class RefrigeratorMalfunctionHandler(KeywordHandler):
 
     def get_facility(self, code, district_supply_point, perform_location_parent_check=True):
         try:
-            facility = SupplyPoint.objects.get(code=code)
+            facility = SupplyPoint.objects.get(code=code, type__code=config.SupplyPointCodes.FACILITY)
         except SupplyPoint.DoesNotExist:
             facility = None
 

--- a/logistics_project/apps/malawi/loader.py
+++ b/logistics_project/apps/malawi/loader.py
@@ -90,16 +90,6 @@ def load_base_locations():
         )
 
 
-def clear_locations():
-    Location.objects.all().delete()
-    LocationType.objects.all().delete()
-
-
-def clear_products():
-    Product.objects.all().delete()
-    ProductType.objects.all().delete()
-
-
 def load_schedules():
     malawi_tz = timezone("Africa/Blantyre") 
     def _malawi_to_utc(hours):

--- a/logistics_project/apps/malawi/management/commands/malawi_init.py
+++ b/logistics_project/apps/malawi/management/commands/malawi_init.py
@@ -1,9 +1,0 @@
-from django.core.management.base import BaseCommand
-from logistics_project.apps.malawi import loader
-
-class Command(BaseCommand):
-    help = "Initialize static data for malawi"
-
-    def handle(self, *args, **options):
-        do_locs = "locations" in args
-        loader.init_static_data(log_to_console=True, do_locations=do_locs)

--- a/logistics_project/apps/malawi/management/commands/recompute_hsa_warehouse_data.py
+++ b/logistics_project/apps/malawi/management/commands/recompute_hsa_warehouse_data.py
@@ -6,6 +6,7 @@ from logistics.models import SupplyPoint
 from logistics_project.apps.malawi.warehouse.models import TimeTracker, OrderRequest, OrderFulfillment
 from rapidsms.contrib.messagelog.models import Message
 from logistics_project.apps.malawi.warehouse.runner import MalawiWarehouseRunner
+from static.malawi.config import SupplyPointCodes
 
 
 class Command(LabelCommand):
@@ -45,5 +46,6 @@ class Command(LabelCommand):
         # update
         warehouse_runner.update_base_level_data(hsa, start, end)
         for parent in hsa.get_parents():
-            print 'updating %s' % parent
-            warehouse_runner.update_aggregated_data(parent, start, end, since=None)
+            if parent.type_id != SupplyPointCodes.ZONE:
+                print 'updating %s' % parent
+                warehouse_runner.update_aggregated_data(parent, start, end, since=None)

--- a/logistics_project/apps/malawi/migrations/0023_add_zones.py
+++ b/logistics_project/apps/malawi/migrations/0023_add_zones.py
@@ -1,0 +1,562 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+from static.malawi.config import SupplyPointCodes, LocationCodes
+
+
+class Migration(DataMigration):
+
+    location_content_type = None
+    zone_supply_point_type = None
+    zone_location_type = None
+    country_location = None
+    country_supply_point = None
+
+    def get_or_create_zone_supply_point_type(self, orm):
+        SupplyPointType = orm['logistics.SupplyPointType']
+
+        obj, _ = SupplyPointType.objects.get_or_create(
+            code=SupplyPointCodes.ZONE,
+            defaults={'name': SupplyPointCodes.ALL[SupplyPointCodes.ZONE]},
+        )
+        obj.name = SupplyPointCodes.ALL[SupplyPointCodes.ZONE]
+        obj.save()
+        return obj
+
+    def get_or_create_zone_location_type(self, orm):
+        LocationType = orm['locations.LocationType']
+
+        obj, _ = LocationType.objects.get_or_create(
+            slug=LocationCodes.ZONE,
+            defaults={'name': LocationCodes.ZONE},
+        )
+        obj.name = LocationCodes.ZONE
+        obj.save()
+        return obj
+
+    def create_zone(self, orm, name, code, child_district_codes):
+        SupplyPoint = orm['logistics.SupplyPoint']
+        Location = orm['locations.Location']
+
+        location, _ = Location.objects.get_or_create(code=code, defaults={'name': name})
+        location.type = self.zone_location_type
+        location.parent_type = self.location_content_type
+        location.parent_id = self.country_location.pk
+        location.name = name
+        location.is_active = True
+        location.save()
+
+        supply_point, _ = SupplyPoint.objects.get_or_create(
+            code=code,
+            defaults={'name': name, 'type': self.zone_supply_point_type, 'location': location}
+        )
+        supply_point.name = name
+        supply_point.active = True
+        supply_point.type = self.zone_supply_point_type
+        supply_point.location = location
+        supply_point.supplied_by = self.country_supply_point
+        supply_point.save()
+
+        for code in child_district_codes:
+            child_district = SupplyPoint.objects.get(code=code)
+            if child_district.type_id != SupplyPointCodes.DISTRICT:
+                raise RuntimeError("Expected District")
+
+            child_district.supplied_by = supply_point
+            child_district.save()
+
+            child_location = child_district.location
+            if child_location.type_id != LocationCodes.DISTRICT:
+                raise RuntimeError("Expected District")
+
+            child_location.parent_id = location.pk
+            child_location.save()
+
+    def forwards(self, orm):
+        ContentType = orm['contenttypes.ContentType']
+        SupplyPoint = orm['logistics.SupplyPoint']
+        SupplyPointType = orm['logistics.SupplyPointType']
+        Location = orm['locations.Location']
+        LocationType = orm['locations.LocationType']
+
+        self.location_content_type = ContentType.objects.get(app_label='locations', model='location')
+        self.zone_supply_point_type = self.get_or_create_zone_supply_point_type(orm)
+        self.zone_location_type = self.get_or_create_zone_location_type(orm)
+        self.country_location = Location.objects.get(type__slug=LocationCodes.COUNTRY)
+        self.country_supply_point = SupplyPoint.objects.get(type__code=SupplyPointCodes.COUNTRY)
+
+        self.create_zone(orm, 'Northern', 'no', ['01', '02', '03', '04', '05', '06', '07'])
+        self.create_zone(orm, 'Central Eastern', 'ce', ['10', '11', '12', '13', '14'])
+        self.create_zone(orm, 'Central Western', 'cw', ['15', '16', '17', '18'])
+        self.create_zone(orm, 'South Eastern', 'se', ['25', '26', '27', '32', '35', '36'])
+        self.create_zone(orm, 'South Western', 'sw', ['28', '29', '30', '31', '33', '34', '37', '99'])
+
+        if (
+            SupplyPoint.objects
+            .filter(type__code=SupplyPointCodes.DISTRICT, supplied_by=self.country_supply_point)
+            .count()
+        ) > 0:
+            raise RuntimeError("Some district SupplyPoints do not have supplied_by set properly")
+
+        if (
+            Location.objects
+            .filter(type__slug=LocationCodes.DISTRICT, parent_id=self.country_location.pk)
+            .count()
+        ) > 0:
+            raise RuntimeError("Some district Locations do not have parent_id set properly")
+
+        print "Successfully created zones and placed them into the Location/SupplyPoint hierarchy."
+
+    def backwards(self, orm):
+        pass
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'locations.location': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Location'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'parent_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'parent_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['locations.Point']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'locations'", 'null': 'True', 'to': "orm['locations.LocationType']"})
+        },
+        'locations.locationtype': {
+            'Meta': {'object_name': 'LocationType'},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50', 'primary_key': 'True'})
+        },
+        'locations.point': {
+            'Meta': {'object_name': 'Point'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'max_digits': '13', 'decimal_places': '10'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'max_digits': '13', 'decimal_places': '10'})
+        },
+        'logistics.contactrole': {
+            'Meta': {'object_name': 'ContactRole'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'responsibilities': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.Responsibility']", 'null': 'True', 'blank': 'True'})
+        },
+        'logistics.defaultmonthlyconsumption': {
+            'Meta': {'unique_together': "(('supply_point_type', 'product'),)", 'object_name': 'DefaultMonthlyConsumption'},
+            'default_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'supply_point_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPointType']"})
+        },
+        'logistics.historicalstockcache': {
+            'Meta': {'object_name': 'HistoricalStockCache'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'month': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']", 'null': 'True'}),
+            'stock': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'year': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        'logistics.logisticsprofile': {
+            'Meta': {'object_name': 'LogisticsProfile'},
+            'can_view_facility_level_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'can_view_hsa_level_data': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'current_dashboard_base_level': ('django.db.models.fields.CharField', [], {'default': "'h'", 'max_length': '1'}),
+            'designation': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['locations.Location']", 'null': 'True', 'blank': 'True'}),
+            'organization': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['malawi.Organization']", 'null': 'True', 'blank': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'unique': 'True'})
+        },
+        'logistics.nagrecord': {
+            'Meta': {'object_name': 'NagRecord'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'nag_type': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'report_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'warning': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        'logistics.product': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Product'},
+            'average_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'emergency_order_level': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'equivalents': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'equivalents_rel_+'", 'null': 'True', 'to': "orm['logistics.Product']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'product_code': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'sms_code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10', 'db_index': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ProductType']"}),
+            'units': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.productreport': {
+            'Meta': {'object_name': 'ProductReport'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['messagelog.Message']", 'null': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {}),
+            'report_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow', 'db_index': 'True'}),
+            'report_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ProductReportType']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'logistics.productreporttype': {
+            'Meta': {'object_name': 'ProductReportType'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.productstock': {
+            'Meta': {'unique_together': "(('supply_point', 'product'),)", 'object_name': 'ProductStock'},
+            'auto_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'days_stocked_out': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'manual_monthly_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'use_auto_consumption': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'logistics.producttype': {
+            'Meta': {'object_name': 'ProductType'},
+            'base_level': ('django.db.models.fields.CharField', [], {'default': "'h'", 'max_length': '1'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '10'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.requisitionreport': {
+            'Meta': {'object_name': 'RequisitionReport'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['messagelog.Message']"}),
+            'report_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'submitted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'logistics.responsibility': {
+            'Meta': {'object_name': 'Responsibility'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'logistics.stockrequest': {
+            'Meta': {'object_name': 'StockRequest'},
+            'amount_approved': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'amount_received': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'amount_requested': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'balance': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True'}),
+            'canceled_for': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.StockRequest']", 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_emergency': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'received_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'received_by'", 'null': 'True', 'to': "orm['rapidsms.Contact']"}),
+            'received_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'requested_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'requested_by'", 'null': 'True', 'to': "orm['rapidsms.Contact']"}),
+            'requested_on': ('django.db.models.fields.DateTimeField', [], {}),
+            'responded_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'responded_by'", 'null': 'True', 'to': "orm['rapidsms.Contact']"}),
+            'responded_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'response_status': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '20', 'db_index': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'logistics.stocktransaction': {
+            'Meta': {'object_name': 'StockTransaction'},
+            'beginning_balance': ('django.db.models.fields.IntegerField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'ending_balance': ('django.db.models.fields.IntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'product_report': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ProductReport']", 'null': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'logistics.stocktransfer': {
+            'Meta': {'object_name': 'StockTransfer'},
+            'amount': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'closed_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'giver': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'giver'", 'null': 'True', 'to': "orm['logistics.SupplyPoint']"}),
+            'giver_unknown': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'initiated_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'receiver': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'receiver'", 'to': "orm['logistics.SupplyPoint']"}),
+            'status': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        'logistics.supplypoint': {
+            'Meta': {'object_name': 'SupplyPoint'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.SupplyPointGroup']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_reported': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['locations.Location']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'supplied_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPointType']"})
+        },
+        'logistics.supplypointgroup': {
+            'Meta': {'object_name': 'SupplyPointGroup'},
+            'code': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'logistics.supplypointtype': {
+            'Meta': {'object_name': 'SupplyPointType'},
+            'code': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50', 'primary_key': 'True'}),
+            'default_monthly_consumptions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.Product']", 'null': 'True', 'through': "orm['logistics.DefaultMonthlyConsumption']", 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'logistics.supplypointwarehouserecord': {
+            'Meta': {'object_name': 'SupplyPointWarehouseRecord'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"})
+        },
+        'malawi.alert': {
+            'Meta': {'object_name': 'Alert'},
+            'eo_total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'eo_with_resupply': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'eo_without_resupply': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'have_stockouts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'num_hsas': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'order_readys': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'products_approved': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'products_requested': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'reporting_receipts': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total_requests': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'without_products_managed': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        'malawi.calculatedconsumption': {
+            'Meta': {'object_name': 'CalculatedConsumption'},
+            'calculated_consumption': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'time_needing_data': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'time_stocked_out': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'time_with_data': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.currentconsumption': {
+            'Meta': {'object_name': 'CurrentConsumption'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'current_daily_consumption': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'stock_on_hand': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.historicalstock': {
+            'Meta': {'object_name': 'HistoricalStock'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'stock': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.orderfulfillment': {
+            'Meta': {'object_name': 'OrderFulfillment'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'quantity_received': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'quantity_requested': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.orderrequest': {
+            'Meta': {'object_name': 'OrderRequest'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'emergency': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.organization': {
+            'Meta': {'object_name': 'Organization'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'managed_supply_points': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'malawi.productavailabilitydata': {
+            'Meta': {'object_name': 'ProductAvailabilityData'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'emergency_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'good_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'managed': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_emergency_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_good_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_over_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_under_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_with_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_without_data': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'managed_and_without_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'over_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.Product']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'under_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'with_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'without_data': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'without_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        'malawi.productavailabilitydatasummary': {
+            'Meta': {'object_name': 'ProductAvailabilityDataSummary'},
+            'any_emergency_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_good_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_managed': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_over_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_under_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_with_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_without_data': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'any_without_stock': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'base_level': ('django.db.models.fields.CharField', [], {'default': "'h'", 'max_length': '1'}),
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.refrigeratormalfunction': {
+            'Meta': {'object_name': 'RefrigeratorMalfunction'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'malfunction_reason': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'reported_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['rapidsms.Contact']"}),
+            'reported_on': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'resolved_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'responded_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'sent_to': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'to': "orm['logistics.SupplyPoint']"}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'to': "orm['logistics.SupplyPoint']"})
+        },
+        'malawi.reportingrate': {
+            'Meta': {'object_name': 'ReportingRate'},
+            'base_level': ('django.db.models.fields.CharField', [], {'default': "'h'", 'max_length': '1'}),
+            'complete': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'on_time': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'reported': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'malawi.timetracker': {
+            'Meta': {'object_name': 'TimeTracker'},
+            'create_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']"}),
+            'time_in_seconds': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'total': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'update_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'messagelog.message': {
+            'Meta': {'object_name': 'Message'},
+            'connection': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rapidsms.Connection']", 'null': 'True'}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rapidsms.Contact']", 'null': 'True'}),
+            'date': ('django.db.models.fields.DateTimeField', [], {}),
+            'direction': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        },
+        'rapidsms.backend': {
+            'Meta': {'object_name': 'Backend'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'})
+        },
+        'rapidsms.connection': {
+            'Meta': {'unique_together': "(('backend', 'identity'),)", 'object_name': 'Connection'},
+            'backend': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rapidsms.Backend']"}),
+            'contact': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rapidsms.Contact']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identity': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'rapidsms.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'commodities': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'reported_by'", 'null': 'True', 'symmetrical': 'False', 'to': "orm['logistics.Product']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '6', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'needs_reminders': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'organization': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['malawi.Organization']", 'null': 'True', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.ContactRole']", 'null': 'True', 'blank': 'True'}),
+            'supply_point': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['logistics.SupplyPoint']", 'null': 'True', 'blank': 'True'})
+        },
+        'taggit.tag': {
+            'Meta': {'object_name': 'Tag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'taggit.taggeditem': {
+            'Meta': {'object_name': 'TaggedItem'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_tagged_items'", 'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'taggit_taggeditem_items'", 'to': "orm['taggit.Tag']"})
+        }
+    }
+
+    complete_apps = ['logistics', 'locations', 'contenttypes', 'malawi']
+    symmetrical = True

--- a/logistics_project/apps/malawi/tests/base.py
+++ b/logistics_project/apps/malawi/tests/base.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from rapidsms.tests.scripted import TestScript
-from logistics_project.apps.malawi import loader
+from logistics_project.apps.malawi.loader import load_static_data_for_tests
 from logistics_project.apps.malawi.management.commands.create_epi_products import create_or_update_epi_products
 from rapidsms.contrib.messagelog.models import Message
 import csv
@@ -43,6 +43,6 @@ class MalawiTestBase(OutputtingTestScript):
     
     def setUp(self):
         super(MalawiTestBase, self).setUp()
-        loader.init_static_data(do_locations=True, do_products=True)
+        load_static_data_for_tests()
         create_or_update_epi_products()
         settings.LOGISTICS_APPROVAL_REQUIRED = False

--- a/logistics_project/apps/malawi/tests/facility/base.py
+++ b/logistics_project/apps/malawi/tests/facility/base.py
@@ -11,5 +11,5 @@ class MalawiFacilityLevelTestBase(MalawiTestBase):
         he = create_manager(self, "16175551002", "robert", config.Roles.EPI_FOCAL, "2616")
         dp = create_manager(self, "16175551003", "ruth", config.Roles.DISTRICT_PHARMACIST, "26")
         de = create_manager(self, "16175551004", "peter", config.Roles.DISTRICT_EPI_COORDINATOR, "26")
-        re = create_manager(self, "16175551005", "sam", config.Roles.REGIONAL_EPI_COORDINATOR, "malawi")
+        re = create_manager(self, "16175551005", "sam", config.Roles.REGIONAL_EPI_COORDINATOR, "se")
         return (ic, sh, he, dp, de, re)

--- a/logistics_project/apps/malawi/tests/facility/stockonhand.py
+++ b/logistics_project/apps/malawi/tests/facility/stockonhand.py
@@ -296,7 +296,7 @@ class TestFacilityLevelStockOnHandMalawi(MalawiFacilityLevelTestBase):
            16175551005 < %(regional_notice)s
         """ % {"confirm": config.Messages.FACILITY_LEVEL_OS_EO_RESPONSE % {"products": "sa, bc"},
                "facility_notice": config.Messages.UNABLE_RESTOCK_FACILITY_NOTIFICATION % {"supply_point": "Ntaja"},
-               "regional_notice": config.Messages.UNABLE_RESTOCK_NORMAL_REGION_ESCALATION %
+               "regional_notice": config.Messages.UNABLE_RESTOCK_NORMAL_ZONE_ESCALATION %
                     {"contact": de.name, "supply_point": "Machinga", "products": "sa, bc"}}
 
         self.runScript(a)
@@ -360,7 +360,7 @@ class TestFacilityLevelStockOnHandMalawi(MalawiFacilityLevelTestBase):
            16175551002 < %(facility_notice)s
            16175551005 < %(regional_notice)s
         """ % {"confirm": config.Messages.FACILITY_LEVEL_OS_EO_RESPONSE % {"products": "bc"},
-               "regional_notice": config.Messages.UNABLE_RESTOCK_EO_REGION_ESCALATION  %
+               "regional_notice": config.Messages.UNABLE_RESTOCK_EO_ZONE_ESCALATION  %
                     {"contact": "peter", "supply_point": "Machinga", "products": "bc"},
                "facility_notice": config.Messages.UNABLE_RESTOCK_EO_FACILITY_NOTIFICATION % {"supply_point": "Ntaja", "products": "bc"}}
         self.runScript(a)
@@ -416,7 +416,7 @@ class TestFacilityLevelStockOnHandMalawi(MalawiFacilityLevelTestBase):
            16175551002 < %(facility_notice)s
            16175551005 < %(regional_notice)s
         """ % {"confirm": config.Messages.FACILITY_LEVEL_OS_EO_RESPONSE % {"products": "sa, bc"},
-               "regional_notice": config.Messages.UNABLE_RESTOCK_STOCKOUT_REGION_ESCALATION  %
+               "regional_notice": config.Messages.UNABLE_RESTOCK_STOCKOUT_ZONE_ESCALATION  %
                     {"contact": "peter", "supply_point": "Machinga", "products": "sa, bc"},
                "facility_notice": config.Messages.UNABLE_RESTOCK_EO_FACILITY_NOTIFICATION % {"supply_point": "Ntaja", "products": "sa, bc"}}
         self.runScript(a)

--- a/logistics_project/apps/malawi/tests/register.py
+++ b/logistics_project/apps/malawi/tests/register.py
@@ -213,8 +213,11 @@ class TestHSARegister(MalawiTestBase):
 
     def testMismatchedManagerRolesAndLocations(self):
         self._run_manager_mismatch_test(config.Roles.IN_CHARGE, '26')
+        self._run_manager_mismatch_test(config.Roles.IN_CHARGE, 'se')
         self._run_manager_mismatch_test(config.Roles.IN_CHARGE, 'malawi')
         self._run_manager_mismatch_test(config.Roles.DISTRICT_PHARMACIST, '2616')
+        self._run_manager_mismatch_test(config.Roles.DISTRICT_PHARMACIST, 'se')
         self._run_manager_mismatch_test(config.Roles.DISTRICT_PHARMACIST, 'malawi')
         self._run_manager_mismatch_test(config.Roles.REGIONAL_EPI_COORDINATOR, '2616')
         self._run_manager_mismatch_test(config.Roles.REGIONAL_EPI_COORDINATOR, '26')
+        self._run_manager_mismatch_test(config.Roles.REGIONAL_EPI_COORDINATOR, 'malawi')

--- a/logistics_project/apps/malawi/tests/util.py
+++ b/logistics_project/apps/malawi/tests/util.py
@@ -45,7 +45,7 @@ def create_manager(test_class, phone, name, role="ic", supply_point_code="2616")
                         {"sp_name": SupplyPoint.objects.get(code=supply_point_code).name,
                          "role": ContactRole.objects.get(code=role).name,
                          "contact_name": name}}
-    elif role in config.Roles.COUNTRY_ONLY:
+    elif role in config.Roles.ZONE_ONLY:
         a = """
                %(phone)s > manage %(name)s %(role)s %(code)s
                %(phone)s < %(confirm)s
@@ -54,7 +54,11 @@ def create_manager(test_class, phone, name, role="ic", supply_point_code="2616")
                 "name": name,
                 "role": role,
                 "code": supply_point_code,
-                "confirm": config.Messages.REGISTRATION_COUNTRY_CONFIRM % {"contact_name": name, "role": ContactRole.objects.get(code=role).name}
+                "confirm": config.Messages.REGISTRATION_ZONE_CONFIRM % {
+                    "contact_name": name,
+                    "role": ContactRole.objects.get(code=role).name,
+                    "sp_name": SupplyPoint.objects.get(code=supply_point_code).name,
+                }
             }
     else:
         raise config.Roles.InvalidRoleException(role)

--- a/logistics_project/apps/malawi/tests/util_functions.py
+++ b/logistics_project/apps/malawi/tests/util_functions.py
@@ -1,0 +1,64 @@
+from logistics.models import SupplyPoint
+from logistics_project.apps.malawi.tests.base import MalawiTestBase
+from logistics_project.apps.malawi.tests.util import create_hsa
+from logistics_project.apps.malawi.util import (hsas_below, hsa_supply_points_below,
+    facility_supply_points_below)
+from rapidsms.contrib.locations.models import Location
+from static.malawi.config import SupplyPointCodes
+
+
+class TestMalawiUtils(MalawiTestBase):
+
+    def assert_hsas_below(self, location_code, expected_list):
+        result = hsas_below(Location.objects.get(code=location_code))
+        self.assertEqual(list(result), expected_list)
+
+    def test_hsas_below(self):
+        hsa = create_hsa(self, '16175551000', 'joe', facility_code='2616')
+
+        # Locations that should have the HSA
+        self.assert_hsas_below('261601', [hsa])
+        self.assert_hsas_below('2616', [hsa])
+        self.assert_hsas_below('26', [hsa])
+        self.assert_hsas_below('se', [hsa])
+        self.assert_hsas_below('malawi', [hsa])
+
+        # Locations that should not have the HSA
+        self.assert_hsas_below('2601', [])
+        self.assert_hsas_below('03', [])
+        self.assert_hsas_below('sw', [])
+
+    def assert_hsa_supply_points_below(self, location_code, expected_list):
+        result = hsa_supply_points_below(Location.objects.get(code=location_code))
+        self.assertEqual(list(result), expected_list)
+
+    def test_hsa_supply_points_below(self):
+        hsa = create_hsa(self, '16175551000', 'joe', facility_code='2616')
+
+        # Locations that should have the HSA
+        self.assert_hsa_supply_points_below('261601', [hsa.supply_point])
+        self.assert_hsa_supply_points_below('2616', [hsa.supply_point])
+        self.assert_hsa_supply_points_below('26', [hsa.supply_point])
+        self.assert_hsa_supply_points_below('se', [hsa.supply_point])
+        self.assert_hsa_supply_points_below('malawi', [hsa.supply_point])
+
+        # Locations that should not have the HSA
+        self.assert_hsas_below('2601', [])
+        self.assert_hsas_below('03', [])
+        self.assert_hsas_below('sw', [])
+
+    def assert_facility_supply_points_below(self, location_code, expected_supply_point_codes):
+        result = facility_supply_points_below(Location.objects.get(code=location_code)).order_by('code')
+        expected_result = SupplyPoint.objects.filter(code__in=expected_supply_point_codes).order_by('code')
+        self.assertEqual(list(result), list(expected_result))
+
+    def test_facility_supply_points_below(self):
+        # This test depends on the data loaded from static/malawi/health_centers.csv
+        self.assert_facility_supply_points_below('9901', ['9901'])
+        self.assert_facility_supply_points_below('99', ['9901', '9902', '9903'])
+        self.assert_facility_supply_points_below('sw', ['9901', '9902', '9903'])
+
+        all_facility_codes = SupplyPoint.objects.filter(
+            type__code=SupplyPointCodes.FACILITY
+        ).values_list('code', flat=True)
+        self.assert_facility_supply_points_below('malawi', list(all_facility_codes))

--- a/logistics_project/apps/malawi/util.py
+++ b/logistics_project/apps/malawi/util.py
@@ -236,7 +236,7 @@ def get_visible_districts(user):
     Given a user, what districts can they see
     """
     if get_view_level(user) == 'national':
-        return list(get_districts(user.is_superuser))
+        return list(get_districts(user.is_superuser).order_by('code'))
 
     profile = user.get_profile()
     loc = None
@@ -267,9 +267,9 @@ def get_visible_districts(user):
                 if l.code != '99' or user.is_superuser:
                     locations.append(l)
         elif loc.type_id == config.LocationCodes.COUNTRY:
-            return list(get_districts(user.is_superuser))
+            return list(get_districts(user.is_superuser).order_by('code'))
 
-    return list(set(locations))
+    return sorted(list(set(locations)), key=lambda loc: loc.code)
 
 
 def get_visible_facilities(user):

--- a/logistics_project/apps/malawi/util.py
+++ b/logistics_project/apps/malawi/util.py
@@ -65,15 +65,22 @@ def hsas_below(location):
     hsas = Contact.objects.filter(role__code="hsa", is_active=True, 
                                   supply_point__active=True) 
     if location:
-        # support up to 4 levels of parentage. this covers
-        # hsa-> facility-> district-> country, which is all we allow you to select
-        
-        hsas = hsas.filter(Q(supply_point__location=location) | \
-                           Q(supply_point__supplied_by__location=location) | \
-                           Q(supply_point__supplied_by__supplied_by__location=location) | \
-                           Q(supply_point__supplied_by__supplied_by__supplied_by__location=location))
+        if location.type_id == config.LocationCodes.HSA:
+            hsas = hsas.filter(supply_point__location=location)
+        elif location.type_id == config.LocationCodes.FACILITY:
+            hsas = hsas.filter(supply_point__supplied_by__location=location)
+        elif location.type_id == config.LocationCodes.DISTRICT:
+            hsas = hsas.filter(supply_point__supplied_by__supplied_by__location=location)
+        elif location.type_id == config.LocationCodes.ZONE:
+            hsas = hsas.filter(supply_point__supplied_by__supplied_by__supplied_by__location=location)
+        elif location.type_id == config.LocationCodes.COUNTRY:
+            hsas = hsas.filter(supply_point__supplied_by__supplied_by__supplied_by__supplied_by__location=location)
+        else:
+            raise config.UnknownLocationCodeException(location.type_id)
+
     return hsas
-    
+
+
 def hsa_supply_points_below(location):
     """
     Given an optional location, return all HSAs below that location.
@@ -82,12 +89,19 @@ def hsa_supply_points_below(location):
     """
     hsa_sps = SupplyPoint.objects.filter(type__code="hsa", active=True, contact__is_active=True)
     if location:
-        # support up to 4 levels of parentage. this covers
-        # hsa-> facility-> district-> country, which is all we allow you to select
-        hsa_sps = hsa_sps.filter(Q(location=location) | \
-                                 Q(supplied_by__location=location) | \
-                                 Q(supplied_by__supplied_by__location=location) | \
-                                 Q(supplied_by__supplied_by__supplied_by__location=location))
+        if location.type_id == config.LocationCodes.HSA:
+            hsa_sps = hsa_sps.filter(location=location)
+        elif location.type_id == config.LocationCodes.FACILITY:
+            hsa_sps = hsa_sps.filter(supplied_by__location=location)
+        elif location.type_id == config.LocationCodes.DISTRICT:
+            hsa_sps = hsa_sps.filter(supplied_by__supplied_by__location=location)
+        elif location.type_id == config.LocationCodes.ZONE:
+            hsa_sps = hsa_sps.filter(supplied_by__supplied_by__supplied_by__location=location)
+        elif location.type_id == config.LocationCodes.COUNTRY:
+            hsa_sps = hsa_sps.filter(supplied_by__supplied_by__supplied_by__supplied_by__location=location)
+        else:
+            raise config.UnknownLocationCodeException(location.type_id)
+
     return hsa_sps
     
     

--- a/logistics_project/apps/malawi/util.py
+++ b/logistics_project/apps/malawi/util.py
@@ -169,12 +169,19 @@ def get_facilities():
 def facility_supply_points_below(location):
     facs = get_facility_supply_points()
     if location:
-        # support up to 3 levels of parentage. this covers
-        # facility-> district--> country, which is all we allow you to select in this case
-        facs = facs.filter(Q(location=location) | \
-                           Q(supplied_by__location=location) | \
-                           Q(supplied_by__supplied_by__location=location))
+        if location.type_id == config.LocationCodes.FACILITY:
+            facs = facs.filter(location=location)
+        elif location.type_id == config.LocationCodes.DISTRICT:
+            facs = facs.filter(supplied_by__location=location)
+        elif location.type_id == config.LocationCodes.ZONE:
+            facs = facs.filter(supplied_by__supplied_by__location=location)
+        elif location.type_id == config.LocationCodes.COUNTRY:
+            facs = facs.filter(supplied_by__supplied_by__supplied_by__location=location)
+        else:
+            raise config.UnknownLocationCodeException(location.type_id)
+
     return facs
+
 
 def get_district_supply_points(include_test=False):
     base = SupplyPoint.objects.filter(active=True,

--- a/logistics_project/apps/malawi/util.py
+++ b/logistics_project/apps/malawi/util.py
@@ -230,34 +230,47 @@ def get_view_level(user):
             return 'national'
     return 'district'
 
+
 def get_visible_districts(user):
     """
     Given a user, what districts can they see
     """
     if get_view_level(user) == 'national':
-        return get_districts(user.is_superuser)
+        return list(get_districts(user.is_superuser))
 
-    prof = user.get_profile()
+    profile = user.get_profile()
     loc = None
     locations = []
-    # add managed districts for the organization
-    if prof and prof.organization:
-        locations = [d.location for d in prof.organization.managed_supply_points.all()]
-    # check user's assigned district
-    if prof and prof.supply_point and prof.supply_point.location:
-        loc = prof.supply_point.location
-    # in case location is set, but not supply_point
-    elif prof and prof.location:
-        loc = prof.location
-    if loc and loc.type.slug == config.LocationCodes.DISTRICT:
-        for l in Location.objects.filter(pk=loc.pk):
-            locations.append(l)
-    elif loc:
-        # support one level deep, assuming that this is national or nothing
-        for l in Location.objects.filter(parent_id=loc.id, is_active=True,\
-                type__slug=config.LocationCodes.DISTRICT):
-            locations.append(l)
-    return locations
+
+    if profile:
+        # Add visible districts based on the user's organization
+
+        if profile.organization:
+            # If the user belongs to an organization, include the districts
+            # managed by the organization.
+            # We only allow settings districts as managed_supply_points for an
+            # organization in the edit organization UI.
+            locations.extend([d.location for d in profile.organization.managed_supply_points.all()])
+
+        if profile.supply_point and profile.supply_point.location:
+            loc = profile.supply_point.location
+        elif profile.location:
+            loc = profile.location
+
+    if loc:
+        # Add visible districts based on the user's profile
+
+        if loc.type_id == config.LocationCodes.DISTRICT:
+            locations.append(loc)
+        elif loc.type_id == config.LocationCodes.ZONE:
+            for l in Location.objects.filter(parent_id=loc.id, is_active=True):
+                if l.code != '99' or user.is_superuser:
+                    locations.append(l)
+        elif loc.type_id == config.LocationCodes.COUNTRY:
+            return list(get_districts(user.is_superuser))
+
+    return list(set(locations))
+
 
 def get_visible_facilities(user):
     """

--- a/logistics_project/apps/malawi/views.py
+++ b/logistics_project/apps/malawi/views.py
@@ -609,10 +609,14 @@ def send_outreach(req):
 def export_amc_csv(request):
     response = HttpResponse(mimetype='text/csv')
     response['Content-Disposition'] = 'attachment; filename=amc.csv'
+    products = Product.objects.filter(type__base_level==config.BaseLevel.HSA).order_by('sms_code')
     writer = UnicodeWriter(response)
-    _, data_rows = amc_plot(SupplyPoint.objects.filter(active=True), request.datespan)
+    _, data_rows = amc_plot(
+        SupplyPoint.objects.filter(active=True, type__code=config.SupplyPointCodes.HSA),
+        request.datespan,
+        products=products
+    )
     datetimes = [datetime(m, y, 1) for m, y in request.datespan.months_iterator()]
-    products = Product.objects.order_by('sms_code')
     row = ['Year', 'Month']
     row.extend([p.sms_code for p in products])
     writer.writerow(row)

--- a/logistics_project/apps/malawi/views.py
+++ b/logistics_project/apps/malawi/views.py
@@ -609,7 +609,7 @@ def send_outreach(req):
 def export_amc_csv(request):
     response = HttpResponse(mimetype='text/csv')
     response['Content-Disposition'] = 'attachment; filename=amc.csv'
-    products = Product.objects.filter(type__base_level==config.BaseLevel.HSA).order_by('sms_code')
+    products = Product.objects.filter(type__base_level=config.BaseLevel.HSA).order_by('sms_code')
     writer = UnicodeWriter(response)
     _, data_rows = amc_plot(
         SupplyPoint.objects.filter(active=True, type__code=config.SupplyPointCodes.HSA),

--- a/logistics_project/apps/malawi/views.py
+++ b/logistics_project/apps/malawi/views.py
@@ -50,8 +50,8 @@ from logistics_project.apps.malawi.models import Organization
 from logistics_project.apps.malawi.forms import OrganizationForm, LogisticsProfileForm,\
     UploadFacilityFileForm, ProductForm, UserForm
 
-from logistics_project.apps.malawi.loader import load_locations,\
-    get_facility_export
+from logistics_project.apps.malawi.loader import (get_facility_export,
+    FacilityLoaderValidationError, FacilityLoader)
 from django.views.decorators.http import require_POST
 from logistics_project.apps.outreach.models import OutreachMessage, OutreachQuota
 from django.db.models.query_utils import Q
@@ -539,10 +539,11 @@ def upload_facilities(request):
     if form.is_valid():
         f = request.FILES['file']
         try: 
-            msgs = load_locations(f)
-            for m in msgs:
-                messages.info(request, m)
-        except Exception, e:
+            count = FacilityLoader(f).run()
+            messages.info(request, "Successfully processed %s rows." % count)
+        except FacilityLoaderValidationError as f:
+            messages.error(request, f.validation_msg)
+        except Exception as e:
             messages.error(request, "Something went wrong with that upload. " 
                            "Please double check the file format or "
                            "try downloading a new copy. Your error message "

--- a/logistics_project/apps/malawi/warehouse/report_views/dashboard.py
+++ b/logistics_project/apps/malawi/warehouse/report_views/dashboard.py
@@ -170,7 +170,11 @@ class View(warehouse_view.DashboardView):
         reporting_supply_point = self.get_reporting_supply_point(request)
 
         # reporting rates + stockout summary
-        child_sps = SupplyPoint.objects.filter(active=True, supplied_by=reporting_supply_point).order_by('name')
+        child_sps = SupplyPoint.objects.filter(active=True).order_by('name')
+        if reporting_supply_point.type_id == SupplyPointCodes.COUNTRY:
+            child_sps = child_sps.filter(supplied_by__supplied_by=reporting_supply_point)
+        else:
+            child_sps = child_sps.filter(supplied_by=reporting_supply_point)
 
         # filter 'test district' out for non-superusers
         if not request.user.is_superuser:

--- a/logistics_project/apps/malawi/warehouse/report_views/hsas.py
+++ b/logistics_project/apps/malawi/warehouse/report_views/hsas.py
@@ -10,6 +10,7 @@ from logistics_project.apps.malawi.util import get_default_supply_point, \
     hsa_supply_points_below, fmt_or_none
 from logistics_project.apps.malawi.warehouse.report_utils import get_hsa_url
 from rapidsms.models import Contact
+from static.malawi.config import SupplyPointCodes
 
 
 class View(warehouse_view.DistrictOnlyView):
@@ -19,7 +20,7 @@ class View(warehouse_view.DistrictOnlyView):
     def custom_context(self, request):
 
         if request.GET.get('hsa_code'):
-            hsa = SupplyPoint.objects.filter(code=request.GET.get('hsa_code'))
+            hsa = SupplyPoint.objects.filter(code=request.GET.get('hsa_code'), type__code=SupplyPointCodes.HSA)
             if hsa.count():
                 self.slug = 'single-hsa'
                 return self.single_hsa_context(request, hsa[0])

--- a/logistics_project/apps/registration/forms.py
+++ b/logistics_project/apps/registration/forms.py
@@ -52,7 +52,7 @@ class ContactForm(forms.ModelForm):
         role_choices = [('', '---------')]
         facility_roles = []
         district_roles = []
-        country_roles = []
+        zone_roles = []
 
         for role in ContactRole.objects.all():
             if role.code == Roles.HSA:
@@ -61,14 +61,14 @@ class ContactForm(forms.ModelForm):
                 facility_roles.append((role.pk, "Facility User - " + role.name))
             elif role.code in Roles.DISTRICT_ONLY:
                 district_roles.append((role.pk, "District User - " + role.name))
-            elif role.code in Roles.COUNTRY_ONLY:
-                country_roles.append((role.pk, "Country User - " + role.name))
+            elif role.code in Roles.ZONE_ONLY:
+                zone_roles.append((role.pk, "Zone User - " + role.name))
             else:
                 role_choices.append((role.pk, role.name))
 
         role_choices.extend(facility_roles)
         role_choices.extend(district_roles)
-        role_choices.extend(country_roles)
+        role_choices.extend(zone_roles)
         return role_choices
 
     def clean_phone(self):
@@ -198,9 +198,9 @@ class CommoditiesContactForm(IntlSMSContactForm):
         elif role.code in Roles.DISTRICT_ONLY and supply_point.type.code != SupplyPointCodes.DISTRICT:
             raise forms.ValidationError("There is a mismatch between role and location. "
                 "You have chosen a district role but a non-district location.")
-        elif role.code in Roles.COUNTRY_ONLY and supply_point.type.code != SupplyPointCodes.COUNTRY:
+        elif role.code in Roles.ZONE_ONLY and supply_point.type.code != SupplyPointCodes.ZONE:
             raise forms.ValidationError("There is a mismatch between role and location. "
-                "You have chosen a country role but not the Malawi location.")
+                "You have chosen a zone role but not a zone location.")
 
         return supply_point
 

--- a/static/malawi/config.py
+++ b/static/malawi/config.py
@@ -272,16 +272,16 @@ class Messages(object):
     UNABLE_RESTOCK_EO_FACILITY_NOTIFICATION = "Dear %(supply_point)s, the District is not able to resupply %(products)s. The EPI Coordinator will work with the Region to resolve this issue."
 
     UNABLE_RESTOCK_EO_DISTRICT_ESCALATION = "%(contact)s reports %(supply_point)s is unable to resupply %(products)s in response to HSA EO. Work with the HSA Supervisor to resolve this issue."
-    UNABLE_RESTOCK_EO_REGION_ESCALATION = "%(contact)s reports %(supply_point)s is unable to resupply %(products)s in response to Facility EO. Work with the EPI Coordinator to resolve this issue."
+    UNABLE_RESTOCK_EO_ZONE_ESCALATION = "%(contact)s reports %(supply_point)s is unable to resupply %(products)s in response to Facility EO. Work with the EPI Coordinator to resolve this issue."
 
     UNABLE_RESTOCK_HSA_NOTIFICATION = "Dear %(hsa)s, the Health Center is unable to resupply any of the products you need. The HSA Supervisor will work with the District to resolve this issue."
     UNABLE_RESTOCK_FACILITY_NOTIFICATION = "Dear %(supply_point)s, the District is unable to resupply any of the products you need. The EPI Coordinator will work with the Region to resolve this issue."
 
     UNABLE_RESTOCK_STOCKOUT_DISTRICT_ESCALATION = "%(contact)s reports %(supply_point)s unable to resupply %(products)s in response to HSA stockout. Please work with the HSA Supervisor to resolve this issue."
-    UNABLE_RESTOCK_STOCKOUT_REGION_ESCALATION = "%(contact)s reports %(supply_point)s unable to resupply %(products)s in response to Facility stockout. Work with the EPI Coordinator to resolve this issue."
+    UNABLE_RESTOCK_STOCKOUT_ZONE_ESCALATION = "%(contact)s reports %(supply_point)s unable to resupply %(products)s in response to Facility stockout. Work with the EPI Coordinator to resolve this issue."
 
     UNABLE_RESTOCK_NORMAL_DISTRICT_ESCALATION = "%(contact)s has reported %(supply_point)s is unable to resupply any of the following %(products)s. Please work with the HSA Supervisor to resolve this issue."
-    UNABLE_RESTOCK_NORMAL_REGION_ESCALATION = "%(contact)s has reported %(supply_point)s is unable to resupply any of the following %(products)s. Work with the EPI Coordinator to resolve this issue."
+    UNABLE_RESTOCK_NORMAL_ZONE_ESCALATION = "%(contact)s has reported %(supply_point)s is unable to resupply any of the following %(products)s. Work with the EPI Coordinator to resolve this issue."
 
     # "Give" keyword (hsa to hsa transfers)
     HSA_LEVEL_TRANSFER_HELP_MESSAGE = "To report a stock transfer, type GIVE [receiving hsa id] [product code] [amount], for example: 'give 100101 zi 20'"

--- a/static/malawi/config.py
+++ b/static/malawi/config.py
@@ -40,7 +40,7 @@ class Roles(object):
     UNIQUE = []#DISTRICT_SUPERVISOR, IMCI_COORDINATOR]
     FACILITY_ONLY = [IN_CHARGE, HSA_SUPERVISOR, EPI_FOCAL]
     DISTRICT_ONLY = [DISTRICT_SUPERVISOR, DISTRICT_PHARMACIST, IMCI_COORDINATOR, DISTRICT_EPI_COORDINATOR]
-    COUNTRY_ONLY = [REGIONAL_EPI_COORDINATOR]
+    ZONE_ONLY = [REGIONAL_EPI_COORDINATOR]
     HSA_SUPERVISOR_ROLES = [HSA_SUPERVISOR, IN_CHARGE]
 
     # Only District users with these roles will get notifications in the EPI workflows and be able to
@@ -209,7 +209,7 @@ class Messages(object):
     HSA_HELP = "Sorry, I didn't understand. To register, send register [first name] [last name] [id] [facility]. Example: 'register john smith 1 1001'"
     REGISTRATION_CONFIRM = "Congratulations %(contact_name)s, you have been registered for the cStock System. Your facility is %(sp_name)s and your role is: %(role)s"
     REGISTRATION_DISTRICT_CONFIRM = "Congratulations %(contact_name)s, you have been registered for the cStock System. Your district is %(sp_name)s and your role is: %(role)s"
-    REGISTRATION_COUNTRY_CONFIRM = "Congratulations %(contact_name)s, you have been registered for the cStock System. Your role is: %(role)s"
+    REGISTRATION_ZONE_CONFIRM = "Congratulations %(contact_name)s, you have been registered for the cStock System. Your zone is %(sp_name)s and your role is: %(role)s"
 
     # "manage" keyword (manger registration)
     MANAGER_HELP = "Sorry, I didn't understand. To register, send manage [first name] [last name] [role] [facility]. Example: 'manage john smith ic 1001'"

--- a/static/malawi/config.py
+++ b/static/malawi/config.py
@@ -136,6 +136,11 @@ class SupplyPointCodes(object):
         HSA: "hsa"
     }
 
+
+class UnknownLocationCodeException(Exception):
+    pass
+
+
 class LocationCodes(object):
     """
     These correspond to LocationType.code

--- a/static/malawi/config.py
+++ b/static/malawi/config.py
@@ -123,12 +123,14 @@ class SupplyPointCodes(object):
     These correspond to SupplyPointType.code
     """
     COUNTRY = "c"
+    ZONE = "z"
     DISTRICT = "d"
     FACILITY = "hf"
     HSA = "hsa"
     
     ALL = {
         COUNTRY: "country",
+        ZONE: "zone",
         DISTRICT: "district",
         FACILITY: "facility",
         HSA: "hsa"
@@ -139,6 +141,7 @@ class LocationCodes(object):
     These correspond to LocationType.code
     """
     COUNTRY = "country"
+    ZONE = "zone"
     DISTRICT = "district"
     FACILITY = "facility"
     HSA = "hsa"

--- a/static/malawi/health_centers.csv
+++ b/static/malawi/health_centers.csv
@@ -1,201 +1,201 @@
-District CODE,District,CODE,Health Centers
-26,Machinga,2616,Ntaja
-26,Machinga,2601,Chamba
-26,Machinga,2614,Ngokwe
-26,Machinga,2650,Mangamba
-26,Machinga,2605,DHO
-26,Machinga,2651,Mlomba
-26,Machinga,2606,Machinga HC
-26,Machinga,2612,Nainunje
-26,Machinga,2604,Kawinga
-26,Machinga,2613,Nayuchi
-26,Machinga,2610,Namandanje
-26,Machinga,2603,Gawanani
-26,Machinga,2609,Mposa
-26,Machinga,2608,Mpiri
-26,Machinga,2652,Ntholowa
-26,Machinga,2617,Nyambi
-26,Machinga,2615,Nsanama
-26,Machinga,2611,Namanja
-26,Machinga,2607,Mbonechera
-26,Machinga,2602,Chikweyo
-26,Machinga,2653,Mkwepere
-3,Nkhatabay,311,Liuzi
-3,Nkhatabay,308,Kachere
-3,Nkhatabay,309,Kande
-3,Nkhatabay,305,Chintheche
-3,Nkhatabay,302,Chesamu
-3,Nkhatabay,316,Maula
-3,Nkhatabay,315,Nkhatabay DHO
-3,Nkhatabay,313,Mpamba
-3,Nkhatabay,303,Chikwina
-3,Nkhatabay,301,Bula
-3,Nkhatabay,319,Usisya
-3,Nkhatabay,310,Khondowe
-3,Nkhatabay,317,Ruarwe
-3,Nkhatabay,306,Chitheka
-3,Nkhatabay,314,Mzenga
-3,Nkhatabay,350,Nthungwa
-3,Nkhatabay,304,Chilambwe
-3,Nkhatabay,312,Lwazi
-3,Nkhatabay,307,Chizumulo
-3,Nkhatabay,318,Likoma
-32,Mulanje,3213,Mulomba
-32,Mulanje,3219,Thuchira
-32,Mulanje,3201,Bondo
-32,Mulanje,3250,Lujeri Estate
-32,Mulanje,3209,Mimosa
-32,Mulanje,3210,Mpala
-32,Mulanje,3202,Chambe
-32,Mulanje,3206,Kambenje
-32,Mulanje,3205,Dzenje
-32,Mulanje,3208,Milonde
-32,Mulanje,3211,Mulanje DHO
-32,Mulanje,3203,Chinyama
-32,Mulanje,3218,Thembe
-32,Mulanje,3204,Chonde
-32,Mulanje,3207,Mbiza
-32,Mulanje,3212,Mulanje Mission
-32,Mulanje,3214,Muloza
-32,Mulanje,3215,Namasalima
-32,Mulanje,3216,Namphungo
-32,Mulanje,3217,Namulenga
-11,Nkhotakota,1104,Dwambazi
-11,Nkhotakota,1150,Lupachi
-11,Nkhotakota,1151,Kasitu
-11,Nkhotakota,1110,Ngala
-11,Nkhotakota,1112,Nkhunga
-11,Nkhotakota,1152,Dwangwa Cane Growers
-11,Nkhotakota,1106,Liwaladzi
-11,Nkhotakota,1153,Msenjere
-11,Nkhotakota,1114,Katimbira
-11,Nkhotakota,1102,Bua
-11,Nkhotakota,1111,DHO/ST
-11,Nkhotakota,1107,Mpamantha
-11,Nkhotakota,1103,Chididi
-11,Nkhotakota,1105,Kapiri
-11,Nkhotakota,1116,Malowa
-11,Nkhotakota,1109,Mwansambo
-11,Nkhotakota,1101,Benga
-11,Nkhotakota,1108,Ntosa
-11,Nkhotakota,1113,Alinafe
-34,Nsanje,3403,Lurwe
-34,Nsanje,3408,Ndamera
-34,Nsanje,3406,Mbenje
-34,Nsanje,3409,Nsanje DH
-34,Nsanje,3401,Chididi
-34,Nsanje,3413,Tengani
-34,Nsanje,3410,Nyamithuthu
-34,Nsanje,3417,Phokera
-34,Nsanje,3402,Kalemba
-34,Nsanje,3412,Sorgin
-34,Nsanje,3414,Trinity
-34,Nsanje,3405,Masenjere
-34,Nsanje,3411,Sankhulani
-34,Nsanje,3404,Makhanga
-10,Kasungu,1005,Kaluluma
-10,Kasungu,1017,Mpepa/Chisinga
-10,Kasungu,1016,Wimbe
-10,Kasungu,1011,Mtunthama
-10,Kasungu,1050,Mziza
-10,Kasungu,1001,Bua
-10,Kasungu,1012,Newa
-10,Kasungu,1004,Dwangwa
-10,Kasungu,1002,Chamwavi
-10,Kasungu,1051,Lodjwa
-10,Kasungu,1009,Kawamba
-10,Kasungu,1052,Khola
-10,Kasungu,1010,Mkhota
-10,Kasungu,1008,Kasungu D.Hospital
-10,Kasungu,1006,Kamboni
-10,Kasungu,1007,Kapelula
-10,Kasungu,1014,Santhe
-10,Kasungu,1053,Gogode
-10,Kasungu,1054,Ofesi
-10,Kasungu,1055,Linyangwa
-10,Kasungu,1003,Chulu
-10,Kasungu,1015,Simlemba
-10,Kasungu,1013,Nkhamenya
-10,Kasungu,1018,Kasalika
-17,Dedza,1701,Bembeke
-17,Dedza,1702,Chikuse
-17,Dedza,1703,Chimoto
-17,Dedza,1704,Chiphwanta 
-17,Dedza,1705,Chitowo
-17,Dedza,1706,Chongoni 
-17,Dedza,1707,Dedza DHO
-17,Dedza,1708,Dzindevu
-17,Dedza,1709,Kafele
-17,Dedza,1710,Kalulu
-17,Dedza,1711,Kanyama 
-17,Dedza,1712,Kanyezi
-17,Dedza,1713,Kaphuka
-17,Dedza,1714,Kasina
-17,Dedza,1715,Lobi
-17,Dedza,1716,Maonde
-17,Dedza,1717,Matumba
-17,Dedza,1718,Mayani
-17,Dedza,1719,Mikondo 
-17,Dedza,1720,Mlangali
-17,Dedza,1721,Mphathi
-17,Dedza,1722,Mphunzi
-17,Dedza,1723,Mtendere 
-17,Dedza,1724,Tsoyo
-17,Dedza,1750,Nakalazi
-17,Dedza,1751,Kaundu
-17,Dedza,1752,Kachindamoto
-17,Dedza,1753,Mtakataka
-17,Dedza,1754,Golomoti
-17,Dedza,1755,Mua
-17,Dedza,1756,Mganja
-17,Dedza,1757,Mjini
-17,Dedza,1758,Mdeza
-15,Lilongwe,1501,Area 18
-15,Lilongwe,1502,Area 25
-15,Lilongwe,1503,Bwaila
-15,Lilongwe,1504,Chokowa
-15,Lilongwe,1505,Chileka
-15,Lilongwe,1506,Chimbalanga
-15,Lilongwe,1507,Chitedze
-15,Lilongwe,1508,Chiunjidza
-15,Lilongwe,1509,Chiwamba
-15,Lilongwe,1510,Chiwe
-15,Lilongwe,1511,Diamphwe
-15,Lilongwe,1512,Dickson
-15,Lilongwe,1513,Dzenza
-15,Lilongwe,1514,Kabudul
-15,Lilongwe,1515,Kang'oma
-15,Lilongwe,1516,Kachale 
-15,Lilongwe,1517,Kawale
-15,Lilongwe,1518,Khongoni
-15,Lilongwe,1519,Likuni
-15,Lilongwe,1520,Lemwe
-15,Lilongwe,1521,Lumbadzi
-15,Lilongwe,1522,Malingunde
-15,Lilongwe,1523,Maluwa
-15,Lilongwe,1524,Matapira
-15,Lilongwe,1525,Mbabvi
-15,Lilongwe,1526,Mbang'ombe I
-15,Lilongwe,1527,Mbang'ombe II
-15,Lilongwe,1528,Mbwatakali
-15,Lilongwe,1529,Ming'ongo
-15,Lilongwe,1530,Mitundu
-15,Lilongwe,1531,Milale
-15,Lilongwe,1532,Mtenthera
-15,Lilongwe,1533,Nambuma
-15,Lilongwe,1534,Nathenje
-15,Lilongwe,1535,Ndaula
-15,Lilongwe,1536,New state house
-15,Lilongwe,1537,Ngoni
-15,Lilongwe,1538,Nkhoma
-15,Lilongwe,1539,Nsaru
-15,Lilongwe,1540,Nthondo
-15,Lilongwe,1541,St Gabriel
-15,Lilongwe,1542,Ukwe
-15,Lilongwe,1543,Dzalanyama
-15,Lilongwe,1544,Police Area 30
-15,Lilongwe,1545,Kamuzu Barracks
-15,Lilongwe,1546,Khasu
-99,Test,9901,Test Facility 1
-99,Test,9902,Test Facility 2
-99,Test,9903,Test Facility 3
+Zone Code,Zone Name,District Code,District Name,Facility Code,Facility Name
+se,South Eastern,26,Machinga,2616,Ntaja
+se,South Eastern,26,Machinga,2601,Chamba
+se,South Eastern,26,Machinga,2614,Ngokwe
+se,South Eastern,26,Machinga,2650,Mangamba
+se,South Eastern,26,Machinga,2605,DHO
+se,South Eastern,26,Machinga,2651,Mlomba
+se,South Eastern,26,Machinga,2606,Machinga HC
+se,South Eastern,26,Machinga,2612,Nainunje
+se,South Eastern,26,Machinga,2604,Kawinga
+se,South Eastern,26,Machinga,2613,Nayuchi
+se,South Eastern,26,Machinga,2610,Namandanje
+se,South Eastern,26,Machinga,2603,Gawanani
+se,South Eastern,26,Machinga,2609,Mposa
+se,South Eastern,26,Machinga,2608,Mpiri
+se,South Eastern,26,Machinga,2652,Ntholowa
+se,South Eastern,26,Machinga,2617,Nyambi
+se,South Eastern,26,Machinga,2615,Nsanama
+se,South Eastern,26,Machinga,2611,Namanja
+se,South Eastern,26,Machinga,2607,Mbonechera
+se,South Eastern,26,Machinga,2602,Chikweyo
+se,South Eastern,26,Machinga,2653,Mkwepere
+no,Northern,3,Nkhatabay,311,Liuzi
+no,Northern,3,Nkhatabay,308,Kachere
+no,Northern,3,Nkhatabay,309,Kande
+no,Northern,3,Nkhatabay,305,Chintheche
+no,Northern,3,Nkhatabay,302,Chesamu
+no,Northern,3,Nkhatabay,316,Maula
+no,Northern,3,Nkhatabay,315,Nkhatabay DHO
+no,Northern,3,Nkhatabay,313,Mpamba
+no,Northern,3,Nkhatabay,303,Chikwina
+no,Northern,3,Nkhatabay,301,Bula
+no,Northern,3,Nkhatabay,319,Usisya
+no,Northern,3,Nkhatabay,310,Khondowe
+no,Northern,3,Nkhatabay,317,Ruarwe
+no,Northern,3,Nkhatabay,306,Chitheka
+no,Northern,3,Nkhatabay,314,Mzenga
+no,Northern,3,Nkhatabay,350,Nthungwa
+no,Northern,3,Nkhatabay,304,Chilambwe
+no,Northern,3,Nkhatabay,312,Lwazi
+no,Northern,3,Nkhatabay,307,Chizumulo
+no,Northern,3,Nkhatabay,318,Likoma
+se,South Eastern,32,Mulanje,3213,Mulomba
+se,South Eastern,32,Mulanje,3219,Thuchira
+se,South Eastern,32,Mulanje,3201,Bondo
+se,South Eastern,32,Mulanje,3250,Lujeri Estate
+se,South Eastern,32,Mulanje,3209,Mimosa
+se,South Eastern,32,Mulanje,3210,Mpala
+se,South Eastern,32,Mulanje,3202,Chambe
+se,South Eastern,32,Mulanje,3206,Kambenje
+se,South Eastern,32,Mulanje,3205,Dzenje
+se,South Eastern,32,Mulanje,3208,Milonde
+se,South Eastern,32,Mulanje,3211,Mulanje DHO
+se,South Eastern,32,Mulanje,3203,Chinyama
+se,South Eastern,32,Mulanje,3218,Thembe
+se,South Eastern,32,Mulanje,3204,Chonde
+se,South Eastern,32,Mulanje,3207,Mbiza
+se,South Eastern,32,Mulanje,3212,Mulanje Mission
+se,South Eastern,32,Mulanje,3214,Muloza
+se,South Eastern,32,Mulanje,3215,Namasalima
+se,South Eastern,32,Mulanje,3216,Namphungo
+se,South Eastern,32,Mulanje,3217,Namulenga
+ce,Central Eastern,11,Nkhotakota,1104,Dwambazi
+ce,Central Eastern,11,Nkhotakota,1150,Lupachi
+ce,Central Eastern,11,Nkhotakota,1151,Kasitu
+ce,Central Eastern,11,Nkhotakota,1110,Ngala
+ce,Central Eastern,11,Nkhotakota,1112,Nkhunga
+ce,Central Eastern,11,Nkhotakota,1152,Dwangwa Cane Growers
+ce,Central Eastern,11,Nkhotakota,1106,Liwaladzi
+ce,Central Eastern,11,Nkhotakota,1153,Msenjere
+ce,Central Eastern,11,Nkhotakota,1114,Katimbira
+ce,Central Eastern,11,Nkhotakota,1102,Bua
+ce,Central Eastern,11,Nkhotakota,1111,DHO/ST
+ce,Central Eastern,11,Nkhotakota,1107,Mpamantha
+ce,Central Eastern,11,Nkhotakota,1103,Chididi
+ce,Central Eastern,11,Nkhotakota,1105,Kapiri
+ce,Central Eastern,11,Nkhotakota,1116,Malowa
+ce,Central Eastern,11,Nkhotakota,1109,Mwansambo
+ce,Central Eastern,11,Nkhotakota,1101,Benga
+ce,Central Eastern,11,Nkhotakota,1108,Ntosa
+ce,Central Eastern,11,Nkhotakota,1113,Alinafe
+se,South Western,34,Nsanje,3403,Lurwe
+se,South Western,34,Nsanje,3408,Ndamera
+se,South Western,34,Nsanje,3406,Mbenje
+se,South Western,34,Nsanje,3409,Nsanje DH
+se,South Western,34,Nsanje,3401,Chididi
+se,South Western,34,Nsanje,3413,Tengani
+se,South Western,34,Nsanje,3410,Nyamithuthu
+se,South Western,34,Nsanje,3417,Phokera
+se,South Western,34,Nsanje,3402,Kalemba
+se,South Western,34,Nsanje,3412,Sorgin
+se,South Western,34,Nsanje,3414,Trinity
+se,South Western,34,Nsanje,3405,Masenjere
+se,South Western,34,Nsanje,3411,Sankhulani
+se,South Western,34,Nsanje,3404,Makhanga
+ce,Central Eastern,10,Kasungu,1005,Kaluluma
+ce,Central Eastern,10,Kasungu,1017,Mpepa/Chisinga
+ce,Central Eastern,10,Kasungu,1016,Wimbe
+ce,Central Eastern,10,Kasungu,1011,Mtunthama
+ce,Central Eastern,10,Kasungu,1050,Mziza
+ce,Central Eastern,10,Kasungu,1001,Bua
+ce,Central Eastern,10,Kasungu,1012,Newa
+ce,Central Eastern,10,Kasungu,1004,Dwangwa
+ce,Central Eastern,10,Kasungu,1002,Chamwavi
+ce,Central Eastern,10,Kasungu,1051,Lodjwa
+ce,Central Eastern,10,Kasungu,1009,Kawamba
+ce,Central Eastern,10,Kasungu,1052,Khola
+ce,Central Eastern,10,Kasungu,1010,Mkhota
+ce,Central Eastern,10,Kasungu,1008,Kasungu D.Hospital
+ce,Central Eastern,10,Kasungu,1006,Kamboni
+ce,Central Eastern,10,Kasungu,1007,Kapelula
+ce,Central Eastern,10,Kasungu,1014,Santhe
+ce,Central Eastern,10,Kasungu,1053,Gogode
+ce,Central Eastern,10,Kasungu,1054,Ofesi
+ce,Central Eastern,10,Kasungu,1055,Linyangwa
+ce,Central Eastern,10,Kasungu,1003,Chulu
+ce,Central Eastern,10,Kasungu,1015,Simlemba
+ce,Central Eastern,10,Kasungu,1013,Nkhamenya
+ce,Central Eastern,10,Kasungu,1018,Kasalika
+cw,Central Western,17,Dedza,1701,Bembeke
+cw,Central Western,17,Dedza,1702,Chikuse
+cw,Central Western,17,Dedza,1703,Chimoto
+cw,Central Western,17,Dedza,1704,Chiphwanta 
+cw,Central Western,17,Dedza,1705,Chitowo
+cw,Central Western,17,Dedza,1706,Chongoni 
+cw,Central Western,17,Dedza,1707,Dedza DHO
+cw,Central Western,17,Dedza,1708,Dzindevu
+cw,Central Western,17,Dedza,1709,Kafele
+cw,Central Western,17,Dedza,1710,Kalulu
+cw,Central Western,17,Dedza,1711,Kanyama 
+cw,Central Western,17,Dedza,1712,Kanyezi
+cw,Central Western,17,Dedza,1713,Kaphuka
+cw,Central Western,17,Dedza,1714,Kasina
+cw,Central Western,17,Dedza,1715,Lobi
+cw,Central Western,17,Dedza,1716,Maonde
+cw,Central Western,17,Dedza,1717,Matumba
+cw,Central Western,17,Dedza,1718,Mayani
+cw,Central Western,17,Dedza,1719,Mikondo 
+cw,Central Western,17,Dedza,1720,Mlangali
+cw,Central Western,17,Dedza,1721,Mphathi
+cw,Central Western,17,Dedza,1722,Mphunzi
+cw,Central Western,17,Dedza,1723,Mtendere 
+cw,Central Western,17,Dedza,1724,Tsoyo
+cw,Central Western,17,Dedza,1750,Nakalazi
+cw,Central Western,17,Dedza,1751,Kaundu
+cw,Central Western,17,Dedza,1752,Kachindamoto
+cw,Central Western,17,Dedza,1753,Mtakataka
+cw,Central Western,17,Dedza,1754,Golomoti
+cw,Central Western,17,Dedza,1755,Mua
+cw,Central Western,17,Dedza,1756,Mganja
+cw,Central Western,17,Dedza,1757,Mjini
+cw,Central Western,17,Dedza,1758,Mdeza
+cw,Central Western,15,Lilongwe,1501,Area 18
+cw,Central Western,15,Lilongwe,1502,Area 25
+cw,Central Western,15,Lilongwe,1503,Bwaila
+cw,Central Western,15,Lilongwe,1504,Chokowa
+cw,Central Western,15,Lilongwe,1505,Chileka
+cw,Central Western,15,Lilongwe,1506,Chimbalanga
+cw,Central Western,15,Lilongwe,1507,Chitedze
+cw,Central Western,15,Lilongwe,1508,Chiunjidza
+cw,Central Western,15,Lilongwe,1509,Chiwamba
+cw,Central Western,15,Lilongwe,1510,Chiwe
+cw,Central Western,15,Lilongwe,1511,Diamphwe
+cw,Central Western,15,Lilongwe,1512,Dickson
+cw,Central Western,15,Lilongwe,1513,Dzenza
+cw,Central Western,15,Lilongwe,1514,Kabudul
+cw,Central Western,15,Lilongwe,1515,Kang'oma
+cw,Central Western,15,Lilongwe,1516,Kachale 
+cw,Central Western,15,Lilongwe,1517,Kawale
+cw,Central Western,15,Lilongwe,1518,Khongoni
+cw,Central Western,15,Lilongwe,1519,Likuni
+cw,Central Western,15,Lilongwe,1520,Lemwe
+cw,Central Western,15,Lilongwe,1521,Lumbadzi
+cw,Central Western,15,Lilongwe,1522,Malingunde
+cw,Central Western,15,Lilongwe,1523,Maluwa
+cw,Central Western,15,Lilongwe,1524,Matapira
+cw,Central Western,15,Lilongwe,1525,Mbabvi
+cw,Central Western,15,Lilongwe,1526,Mbang'ombe I
+cw,Central Western,15,Lilongwe,1527,Mbang'ombe II
+cw,Central Western,15,Lilongwe,1528,Mbwatakali
+cw,Central Western,15,Lilongwe,1529,Ming'ongo
+cw,Central Western,15,Lilongwe,1530,Mitundu
+cw,Central Western,15,Lilongwe,1531,Milale
+cw,Central Western,15,Lilongwe,1532,Mtenthera
+cw,Central Western,15,Lilongwe,1533,Nambuma
+cw,Central Western,15,Lilongwe,1534,Nathenje
+cw,Central Western,15,Lilongwe,1535,Ndaula
+cw,Central Western,15,Lilongwe,1536,New state house
+cw,Central Western,15,Lilongwe,1537,Ngoni
+cw,Central Western,15,Lilongwe,1538,Nkhoma
+cw,Central Western,15,Lilongwe,1539,Nsaru
+cw,Central Western,15,Lilongwe,1540,Nthondo
+cw,Central Western,15,Lilongwe,1541,St Gabriel
+cw,Central Western,15,Lilongwe,1542,Ukwe
+cw,Central Western,15,Lilongwe,1543,Dzalanyama
+cw,Central Western,15,Lilongwe,1544,Police Area 30
+cw,Central Western,15,Lilongwe,1545,Kamuzu Barracks
+cw,Central Western,15,Lilongwe,1546,Khasu
+sw,South Western,99,Test,9901,Test Facility 1
+sw,South Western,99,Test,9902,Test Facility 2
+sw,South Western,99,Test,9903,Test Facility 3


### PR DESCRIPTION
This introduces the Zone level into the location hierarchy and accounts for it where necessary in the facility-level SMS workflows. No change actually needed to be made to the order stockout process since it just looks at the district's parent location which will now be the zone.

For the warehouse runner, I took the approach of not storing (i.e., not aggregating) any data at the zone level since it's not a requirement.

Opening this for review, I still need to go through and make sure there's nowhere else that will fail with the introduction of a new level, and also add some tests.

@czue 