### PR TITLE
EPI: Only show data for piloting districts

### DIFF
--- a/logistics_project/apps/malawi/util.py
+++ b/logistics_project/apps/malawi/util.py
@@ -419,3 +419,10 @@ def filter_district_list_for_epi(district_list):
     Works on a list of SupplyPoint districts or Location districts.
     """
     return filter(lambda d: d.code in settings.EPI_DISTRICT_CODES, district_list)
+
+
+def filter_facility_supply_point_queryset_for_epi(facility_qs):
+    """
+    Works on a queryset of SupplyPoint facilities.
+    """
+    return facility_qs.filter(supplied_by__code__in=settings.EPI_DISTRICT_CODES)

--- a/logistics_project/apps/malawi/util.py
+++ b/logistics_project/apps/malawi/util.py
@@ -432,4 +432,4 @@ def filter_facility_location_queryset_for_epi(facility_qs):
     """
     Works on a queryset of Location facilities.
     """
-    return facility_qs.filter(supply_point__supplied_by__code__in=settings.EPI_DISTRICT_CODES)
+    return facility_qs.filter(supplypoint__supplied_by__code__in=settings.EPI_DISTRICT_CODES)

--- a/logistics_project/apps/malawi/util.py
+++ b/logistics_project/apps/malawi/util.py
@@ -405,3 +405,17 @@ def get_or_create_user_profile(user):
         return user.get_profile()
     except ObjectDoesNotExist:
         return LogisticsProfile.objects.create(user=user)
+
+
+def filter_district_queryset_for_epi(district_qs):
+    """
+    Works on a queryset of SupplyPoint districts or Location districts.
+    """
+    return district_qs.filter(code__in=settings.EPI_DISTRICT_CODES)
+
+
+def filter_district_list_for_epi(district_list):
+    """
+    Works on a list of SupplyPoint districts or Location districts.
+    """
+    return filter(lambda d: d.code in settings.EPI_DISTRICT_CODES, district_list)

--- a/logistics_project/apps/malawi/util.py
+++ b/logistics_project/apps/malawi/util.py
@@ -426,3 +426,10 @@ def filter_facility_supply_point_queryset_for_epi(facility_qs):
     Works on a queryset of SupplyPoint facilities.
     """
     return facility_qs.filter(supplied_by__code__in=settings.EPI_DISTRICT_CODES)
+
+
+def filter_facility_location_queryset_for_epi(facility_qs):
+    """
+    Works on a queryset of Location facilities.
+    """
+    return facility_qs.filter(supply_point__supplied_by__code__in=settings.EPI_DISTRICT_CODES)

--- a/logistics_project/apps/malawi/warehouse/report_views/dashboard.py
+++ b/logistics_project/apps/malawi/warehouse/report_views/dashboard.py
@@ -3,7 +3,8 @@ from django.db.models import Count
 from django.utils.datastructures import SortedDict
 from logistics.models import SupplyPoint
 from logistics_project.apps.malawi.models import RefrigeratorMalfunction
-from logistics_project.apps.malawi.util import pct, fmt_pct, get_default_supply_point, remove_test_district
+from logistics_project.apps.malawi.util import (pct, fmt_pct, get_default_supply_point, remove_test_district,
+    filter_district_queryset_for_epi)
 from logistics_project.apps.malawi.warehouse.models import ProductAvailabilityDataSummary,\
     Alert
 from logistics_project.apps.malawi.warehouse.report_utils import current_report_period, \
@@ -173,6 +174,8 @@ class View(warehouse_view.DashboardView):
         child_sps = SupplyPoint.objects.filter(active=True).order_by('name')
         if reporting_supply_point.type_id == SupplyPointCodes.COUNTRY:
             child_sps = child_sps.filter(supplied_by__supplied_by=reporting_supply_point)
+            if request.base_level_is_facility:
+                child_sps = filter_district_queryset_for_epi(child_sps)
         else:
             child_sps = child_sps.filter(supplied_by=reporting_supply_point)
 

--- a/logistics_project/apps/malawi/warehouse/report_views/resupply_qts_required.py
+++ b/logistics_project/apps/malawi/warehouse/report_views/resupply_qts_required.py
@@ -1,9 +1,10 @@
 from django.db.models import Q
 from logistics.models import StockRequest, Product, SupplyPoint
 from logistics_project.apps.malawi.warehouse import warehouse_view
-from logistics_project.apps.malawi.util import get_default_supply_point,\
-    facility_supply_points_below, is_district, is_country, is_facility,\
-    hsa_supply_points_below, get_district_supply_points
+from logistics_project.apps.malawi.util import (get_default_supply_point,
+    facility_supply_points_below, is_district, is_country, is_facility,
+    hsa_supply_points_below, get_district_supply_points,
+    filter_district_queryset_for_epi)
 from collections import defaultdict
 from static.malawi.config import BaseLevel
 
@@ -32,6 +33,8 @@ class View(warehouse_view.DistrictOnlyView):
         if is_country(sp):
             table["header"] = ["District Name"]
             facilities = get_district_supply_points(request.user.is_superuser)
+            if request.base_level_is_facility:
+                facilities = filter_district_queryset_for_epi(facilities)
         elif is_district(sp):
             table["header"] = ["Facility Name"]
             facilities = facility_supply_points_below(sp.location)

--- a/logistics_project/apps/malawi/warehouse/warehouse_view.py
+++ b/logistics_project/apps/malawi/warehouse/warehouse_view.py
@@ -10,7 +10,8 @@ from logistics.util import config
 from logistics_project.apps.malawi.util import (get_facilities, get_districts,
     get_country_sp, pct, get_default_supply_point, get_visible_districts,
     get_visible_facilities, get_all_visible_locations, get_view_level, get_visible_hsas,
-    get_facility_supply_points, filter_district_queryset_for_epi, filter_district_list_for_epi)
+    get_facility_supply_points, filter_district_queryset_for_epi, filter_district_list_for_epi,
+    filter_facility_supply_point_queryset_for_epi, filter_facility_location_queryset_for_epi)
 from logistics_project.apps.malawi.warehouse.models import ProductAvailabilityData, ReportingRate
 from logistics_project.apps.malawi.warehouse.report_utils import current_report_period
 
@@ -114,8 +115,8 @@ class MalawiWarehouseView(ReportView):
             facility_count = get_facility_supply_points().count()
         elif request.base_level_is_facility:
             districts = filter_district_queryset_for_epi(districts)
-            visible_facilities = visible_facilities.filter(supplypoint__supplied_by__code__in=settings.EPI_DISTRICT_CODES)
-            facility_count = get_facility_supply_points().filter(supplied_by__code__in=settings.EPI_DISTRICT_CODES).count()
+            visible_facilities = filter_facility_location_queryset_for_epi(visible_facilities)
+            facility_count = filter_facility_supply_point_queryset_for_epi(get_facility_supply_points()).count()
 
         querystring = '?'
         for key in request.GET.keys():

--- a/logistics_project/apps/malawi/warehouse/warehouse_view.py
+++ b/logistics_project/apps/malawi/warehouse/warehouse_view.py
@@ -112,11 +112,15 @@ class MalawiWarehouseView(ReportView):
 
         if request.base_level_is_hsa:
             visible_hsas = get_visible_hsas(request.user)
-            facility_count = get_facility_supply_points().count()
+            all_districts = get_districts()
         elif request.base_level_is_facility:
             districts = filter_district_queryset_for_epi(districts)
             visible_facilities = filter_facility_location_queryset_for_epi(visible_facilities)
-            facility_count = filter_facility_supply_point_queryset_for_epi(get_facility_supply_points()).count()
+            all_districts = filter_district_queryset_for_epi(get_districts())
+
+        # Get counts for national view sidebar
+        district_count = all_districts.count()
+        facility_count = get_facilities().filter(parent_id__in=all_districts.values_list('id', flat=True)).count()
 
         querystring = '?'
         for key in request.GET.keys():
@@ -126,7 +130,7 @@ class MalawiWarehouseView(ReportView):
             "default_chart_width": 530 if settings.STYLE=='both' else 730,
             "country": country,
             "districts": districts,
-            "district_count": districts.count(),
+            "district_count": district_count,
             "facilities": visible_facilities,
             "facility_count": facility_count,
             "visible_hsas": visible_hsas,

--- a/logistics_project/apps/malawi/warehouse/warehouse_view.py
+++ b/logistics_project/apps/malawi/warehouse/warehouse_view.py
@@ -10,7 +10,7 @@ from logistics.util import config
 from logistics_project.apps.malawi.util import (get_facilities, get_districts,
     get_country_sp, pct, get_default_supply_point, get_visible_districts,
     get_visible_facilities, get_all_visible_locations, get_view_level, get_visible_hsas,
-    get_facility_supply_points)
+    get_facility_supply_points, filter_district_queryset_for_epi, filter_district_list_for_epi)
 from logistics_project.apps.malawi.warehouse.models import ProductAvailabilityData, ReportingRate
 from logistics_project.apps.malawi.warehouse.report_utils import current_report_period
 
@@ -113,7 +113,7 @@ class MalawiWarehouseView(ReportView):
             visible_hsas = get_visible_hsas(request.user)
             facility_count = get_facility_supply_points().count()
         elif request.base_level_is_facility:
-            districts = districts.filter(code__in=settings.EPI_DISTRICT_CODES)
+            districts = filter_district_queryset_for_epi(districts)
             visible_facilities = visible_facilities.filter(supplypoint__supplied_by__code__in=settings.EPI_DISTRICT_CODES)
             facility_count = get_facility_supply_points().filter(supplied_by__code__in=settings.EPI_DISTRICT_CODES).count()
 
@@ -190,7 +190,7 @@ class DistrictOnlyView(MalawiWarehouseView):
         base_context = super(DistrictOnlyView, self).shared_context(request)
         visible_districts = get_visible_districts(request.user)
         if request.base_level_is_facility:
-            visible_districts = filter(lambda d: d.code in settings.EPI_DISTRICT_CODES, visible_districts)
+            visible_districts = filter_district_list_for_epi(visible_districts)
 
         view_level = get_view_level(request.user)
         base_context["districts"] = visible_districts

--- a/logistics_project/apps/malawi/warehouse/warehouse_view.py
+++ b/logistics_project/apps/malawi/warehouse/warehouse_view.py
@@ -7,9 +7,10 @@ from logistics.models import Product, SupplyPoint
 from logistics.reports import ReportView
 from logistics.util import config
 
-from logistics_project.apps.malawi.util import get_facilities, get_districts,\
-    get_country_sp, pct, get_default_supply_point, get_visible_districts,\
-    get_visible_facilities, get_all_visible_locations, get_view_level, get_visible_hsas
+from logistics_project.apps.malawi.util import (get_facilities, get_districts,
+    get_country_sp, pct, get_default_supply_point, get_visible_districts,
+    get_visible_facilities, get_all_visible_locations, get_view_level, get_visible_hsas,
+    get_facility_supply_points)
 from logistics_project.apps.malawi.warehouse.models import ProductAvailabilityData, ReportingRate
 from logistics_project.apps.malawi.warehouse.report_utils import current_report_period
 
@@ -104,24 +105,29 @@ class MalawiWarehouseView(ReportView):
             pass
 
         default_sp = get_default_supply_point(request.user)
+        districts = get_districts(request.user.is_superuser)
         visible_facilities = get_visible_facilities(request.user).order_by('parent_id')
         visible_hsas = []
+
         if request.base_level_is_hsa:
             visible_hsas = get_visible_hsas(request.user)
+            facility_count = get_facility_supply_points().count()
+        elif request.base_level_is_facility:
+            districts = districts.filter(code__in=settings.EPI_DISTRICT_CODES)
+            visible_facilities = visible_facilities.filter(supplypoint__supplied_by__code__in=settings.EPI_DISTRICT_CODES)
+            facility_count = get_facility_supply_points().filter(supplied_by__code__in=settings.EPI_DISTRICT_CODES).count()
 
         querystring = '?'
         for key in request.GET.keys():
             querystring += '%s=%s&' % (key, request.GET[key])
 
-        districts = get_districts(request.user.is_superuser)
         base_context.update({
             "default_chart_width": 530 if settings.STYLE=='both' else 730,
             "country": country,
             "districts": districts,
             "district_count": districts.count(),
             "facilities": visible_facilities,
-            "facility_count": SupplyPoint.objects.filter(active=True, 
-                                                         type__code=config.SupplyPointCodes.FACILITY).count(),
+            "facility_count": facility_count,
             "visible_hsas": visible_hsas,
             "hsas": SupplyPoint.objects.filter(active=True, type__code="hsa").count(),
             "reporting_rate": pct_reported,
@@ -183,6 +189,9 @@ class DistrictOnlyView(MalawiWarehouseView):
     def shared_context(self, request):
         base_context = super(DistrictOnlyView, self).shared_context(request)
         visible_districts = get_visible_districts(request.user)
+        if request.base_level_is_facility:
+            visible_districts = filter(lambda d: d.code in settings.EPI_DISTRICT_CODES, visible_districts)
+
         view_level = get_view_level(request.user)
         base_context["districts"] = visible_districts
         base_context["national_view_level"] = view_level == 'national'

--- a/logistics_project/settings.py
+++ b/logistics_project/settings.py
@@ -185,6 +185,13 @@ STATIC_URL = "/static"
 REPORT_URL = "/malawi/r"
 EPI_REPORT_URL = "/malawi/f"
 
+# This is a list of all district codes currently participating in EPI workflows.
+# This list controls which districts are displayed in filters in reports as
+# well as which districts are considered for country-level aggregation in the
+# warehouse runner (which matters for some models, like reporting rates).
+# To change which districts participate in EPI, just update this list.
+EPI_DISTRICT_CODES = ['12', '13', '31', '37', '99']
+
 # email settings used for sending out email reports
 EMAIL_LOGIN="name@dimagi.com"
 EMAIL_PASSWORD="changeme"


### PR DESCRIPTION
Updates the reports and the warehouse runner to only report on piloting districts.

The warehouse runner still runs against non-participating facilities and districts, only that data is not aggregated at the national level (which makes a difference for models like reporting rate). It is also not displayed in the reports or dropdowns in the location filters.

@czue 