### PR TITLE
Historical EPI data fix for piloting districts

### DIFF
--- a/logistics_project/apps/malawi/management/commands/recalculate_epi_country_level_aggregates.py
+++ b/logistics_project/apps/malawi/management/commands/recalculate_epi_country_level_aggregates.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from django.core.management.base import BaseCommand
+from logistics.models import SupplyPoint
+from logistics_project.apps.malawi.warehouse.runner import MalawiWarehouseRunner
+from static.malawi.config import BaseLevel, SupplyPointCodes
+
+
+class Command(BaseCommand):
+    help = "Recalculates country-level aggregates for EPI"
+
+    def handle(self, *args, **options):
+        country = SupplyPoint.objects.get(type__code=SupplyPointCodes.COUNTRY)
+        MalawiWarehouseRunner().update_aggregated_data(
+            country,
+            datetime(2016, 11, 1),
+            datetime(2017, 2, 1),
+            datetime(2016, 11, 1),
+            base_level=BaseLevel.FACILITY
+        )

--- a/logistics_project/apps/malawi/warehouse/runner.py
+++ b/logistics_project/apps/malawi/warehouse/runner.py
@@ -497,15 +497,10 @@ def update_consumption_times(since):
     """
     Update the consumption time_with_data values for any supply point / product pairings
     where the supply point doesn't explicitly supply the product.
-    This function only works against base level data.
     """
     # any consumption value that was touched potentially needs to have its
     # time_needing_data updated
-    consumptions_to_update = CalculatedConsumption.objects.filter(
-        Q(product__type__base_level=BaseLevel.HSA, supply_point__type__code=SupplyPointCodes.HSA) |
-        Q(product__type__base_level=BaseLevel.FACILITY, supply_point__type__code=SupplyPointCodes.FACILITY),
-        update_date__gte=since
-    )
+    consumptions_to_update = CalculatedConsumption.objects.filter(update_date__gte=since)
     count = consumptions_to_update.count()
     print 'updating %s consumption objects' % count
     for i, c in enumerate(consumptions_to_update.iterator()):

--- a/logistics_project/apps/malawi/warehouse/runner.py
+++ b/logistics_project/apps/malawi/warehouse/runner.py
@@ -497,10 +497,15 @@ def update_consumption_times(since):
     """
     Update the consumption time_with_data values for any supply point / product pairings
     where the supply point doesn't explicitly supply the product.
+    This function only works against base level data.
     """
     # any consumption value that was touched potentially needs to have its
     # time_needing_data updated
-    consumptions_to_update = CalculatedConsumption.objects.filter(update_date__gte=since)
+    consumptions_to_update = CalculatedConsumption.objects.filter(
+        Q(product__type__base_level=BaseLevel.HSA, supply_point__type__code=SupplyPointCodes.HSA) |
+        Q(product__type__base_level=BaseLevel.FACILITY, supply_point__type__code=SupplyPointCodes.FACILITY),
+        update_date__gte=since
+    )
     count = consumptions_to_update.count()
     print 'updating %s consumption objects' % count
     for i, c in enumerate(consumptions_to_update.iterator()):


### PR DESCRIPTION
Adds a command to recompute aggregates at the country level for historical epi data.

@czue 