### PR TITLE
Show 0 instead of '-' in months of stock table for stockouts

### DIFF
--- a/logistics_project/apps/malawi/warehouse/report_views/stock_status.py
+++ b/logistics_project/apps/malawi/warehouse/report_views/stock_status.py
@@ -96,7 +96,7 @@ class View(warehouse_view.DistrictOnlyView):
                 ps = ProductStock.objects.filter(supply_point=supply_point, product=product)
                 if ps.count():
                     mr = ps[0].months_remaining
-                    if mr:
+                    if mr is not None:
                         temp.append('%.1f' % mr)
                     else:
                         temp.append('-')


### PR DESCRIPTION
"-" was being shown instead of "0" in the months of stock table when there was a stockout.

@calellowitz cstock buddy